### PR TITLE
Comprehensive package improvements: lifecycle fixes, security, abort signals, enterprise, tests, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: lint · typecheck · test · build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Enable Corepack (for Yarn 3)
+        run: corepack enable
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+            .yarn/install-state.gz
+          key: yarn-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ matrix.node-version }}-
+            yarn-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Test
+        run: yarn test:ci
+
+      - name: Build
+        run: yarn prepare

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A lightweight React Native component for seamless integration of Google reCAPTCH
 - **Auto-Recovery**: Automatically handles reset and retry when reCAPTCHA is not ready.
 - **Network Error Detection**: Comprehensive offline/network error detection with immediate feedback.
 - **Custom Actions**: Supports custom action names for fine-grained security policies.
+- **AbortSignal Support**: Cancel in-flight token requests with the standard `AbortSignal` API.
+- **reCAPTCHA Enterprise**: Opt-in support for the Enterprise endpoint.
 - **WebView-Based**: Leverages `react-native-webview` for reliable reCAPTCHA rendering.
 - **TypeScript Support**: Fully typed for better developer experience.
 - **Debug Mode**: Optional test mode for detailed logging during development.
@@ -140,28 +142,31 @@ export default App;
 
 ### Props
 
-| Prop                     | Type                                | Required | Default    | Description                                                                 |
-|--------------------------|-------------------------------------|----------|------------|-----------------------------------------------------------------------------|
-| `siteKey`                | `string`                            | Yes      |            | Google reCAPTCHA v3 Site Key.                                               |
-| `baseUrl`                | `string`                            | Yes      |            | Registered domain for reCAPTCHA (e.g., `https://api.mydomain.com`).         |
-| `action`                 | `string`                            | No       | `'submit'` | Default action name for reCAPTCHA requests.                                 |
-| `onVerify`               | `(token: string) => void`           | No       |            | Callback triggered on successful token generation.                          |
-| `onError`                | `(error: string) => void`           | No       |            | Callback triggered on reCAPTCHA errors.                                     |
-| `onLoadStart`            | `() => void`                        | No       |            | Callback triggered when WebView starts loading.                             |
-| `onLoadEnd`               | `() => void`                        | No       |            | Callback triggered when WebView finishes loading.                           |
-| `style`                  | `ViewStyle`                         | No       |            | Styles for the underlying `WebView`.                                        |
-| `containerStyle`         | `ViewStyle`                         | No       |            | Styles for the container wrapping the `WebView`.                            |
-| `initializationTimeout`  | `number`                            | No       | `30000`     | Timeout in milliseconds for reCAPTCHA initialization (default: 30s).        |
-| `tokenRequestTimeout`    | `number`                            | No       | `15000`     | Timeout in milliseconds for token requests (default: 15s).                  |
-| `testMode`               | `boolean`                           | No       | `false`     | Enable debug logging for troubleshooting.                                   |
+| Prop                     | Type                                          | Required | Default    | Description                                                                 |
+|--------------------------|-----------------------------------------------|----------|------------|-----------------------------------------------------------------------------|
+| `siteKey`                | `string`                                      | Yes      |            | Google reCAPTCHA v3 Site Key.                                               |
+| `baseUrl`                | `string`                                      | Yes      |            | Registered domain for reCAPTCHA (e.g., `https://api.mydomain.com`).         |
+| `action`                 | `string`                                      | No       | `'submit'` | Default action name for reCAPTCHA requests.                                 |
+| `onVerify`               | `(token: string, action: string) => void`     | No       |            | Callback triggered on successful token generation. Receives the resolved action so you can route tokens when running multiple actions through one component. |
+| `onError`                | `(error: string) => void`                     | No       |            | Callback triggered on reCAPTCHA errors.                                     |
+| `onLoadStart`            | `() => void`                                  | No       |            | Callback triggered when the WebView starts loading.                         |
+| `onLoadEnd`              | `() => void`                                  | No       |            | Callback triggered once per load cycle when the WebView finishes loading.   |
+| `style`                  | `ViewStyle`                                   | No       |            | Styles for the underlying `WebView`.                                        |
+| `containerStyle`         | `ViewStyle`                                   | No       |            | Styles for the container wrapping the `WebView`.                            |
+| `initializationTimeout`  | `number`                                      | No       | `30000`    | Timeout in milliseconds for reCAPTCHA initialization (default: 30s).        |
+| `tokenRequestTimeout`    | `number`                                      | No       | `15000`    | Timeout in milliseconds for token requests (default: 15s).                  |
+| `testMode`               | `boolean`                                     | No       | `false`    | Enable debug logging for troubleshooting.                                   |
+| `useEnterprise`          | `boolean`                                     | No       | `false`    | Use reCAPTCHA Enterprise (`grecaptcha.enterprise.execute`) instead of standard v3. |
+| `originWhitelist`        | `readonly string[]`                           | No       | `[google + baseUrl]` | Origins the WebView is allowed to navigate to. Pass `['*']` to opt out. |
+| `mixedContentMode`       | `'never' \| 'always' \| 'compatibility'`      | No       | `'never'`  | Android WebView mixed-content policy. `'never'` blocks HTTP-in-HTTPS content. |
 
 ### Methods
 
-| Method     | Signature                                    | Description                                                       |
-|------------|----------------------------------------------|-------------------------------------------------------------------|
-| `getToken` | `(action?: string) => Promise<string>`      | Retrieves a reCAPTCHA token. Automatically handles reset and readiness checks. Rejects on network errors or timeouts. |
-| `isReady`  | `() => boolean`                              | Returns `true` if reCAPTCHA is ready and no errors occurred.    |
-| `reset`    | `() => Promise<void>`                       | Resets the component and reloads the WebView. Returns a Promise that resolves when reset is complete. |
+| Method     | Signature                                                                 | Description                                                       |
+|------------|---------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `getToken` | `(action?: string, options?: { signal?: AbortSignal }) => Promise<string>` | Retrieves a reCAPTCHA token. Pass `options.signal` to cancel an in-flight request; the promise rejects with `'Token request was aborted.'`. |
+| `isReady`  | `() => boolean`                                                           | Returns `true` if reCAPTCHA is ready and no errors occurred.    |
+| `reset`    | `() => Promise<void>`                                                     | Resets the component and reloads the WebView. In-flight token requests are rejected with `'Token request cancelled: reCAPTCHA was reset.'` before the reload begins. |
 
 **Example**:
 
@@ -190,6 +195,31 @@ const handleReset = async () => {
   await recaptchaRef.current?.reset();
   console.log('reCAPTCHA reset complete');
 };
+
+// Cancel an in-flight request when the user navigates away
+const handleNavigateAway = async () => {
+  const controller = new AbortController();
+  const tokenPromise = recaptchaRef.current?.getToken('checkout', {
+    signal: controller.signal,
+  });
+
+  // ... user navigates ...
+  controller.abort();
+
+  try {
+    await tokenPromise;
+  } catch (err) {
+    // err.message === 'Token request was aborted.'
+  }
+};
+
+// reCAPTCHA Enterprise
+<ReCaptcha
+  ref={recaptchaRef}
+  siteKey={ENTERPRISE_SITE_KEY}
+  baseUrl={BASE_URL}
+  useEnterprise
+/>;
 ```
 
 ## 🛠 How It Works

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,18 +1,40 @@
-module.exports = {
-  presets: [
-    ['module:react-native-builder-bob/babel-preset', { 
-      modules: 'commonjs',
-      useESModules: false
-    }],
-  ],
-  sourceMaps: false,
-  plugins: [
-    ['@babel/plugin-transform-modules-commonjs', {
-      strict: false,
-      strictMode: false
-    }],
-    ['@babel/plugin-transform-react-jsx', {
-      runtime: 'classic'
-    }]
-  ]
+module.exports = (api) => {
+  const isTest = api.env('test');
+  api.cache.using(() => (isTest ? 'test' : 'build'));
+
+  if (isTest) {
+    // Tests run through jest; use the standard RN babel preset so Flow types
+    // in node_modules/react-native are stripped and TS/JSX is handled.
+    return {
+      presets: ['@react-native/babel-preset'],
+    };
+  }
+
+  return {
+    presets: [
+      [
+        'module:react-native-builder-bob/babel-preset',
+        {
+          modules: 'commonjs',
+          useESModules: false,
+        },
+      ],
+    ],
+    sourceMaps: false,
+    plugins: [
+      [
+        '@babel/plugin-transform-modules-commonjs',
+        {
+          strict: false,
+          strictMode: false,
+        },
+      ],
+      [
+        '@babel/plugin-transform-react-jsx',
+        {
+          runtime: 'classic',
+        },
+      ],
+    ],
+  };
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'react-native',
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.{ts,tsx}'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|@react-native|react-native-webview)',
+  ],
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/__tests__/**'],
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+// Controllable mock for react-native-webview. The mock factory keeps its
+// own state object; tests access it via global.__getMockWebView() to drive
+// lifecycle events (onLoadStart, onLoadEnd, onMessage) and inspect
+// injectJavaScript / reload calls.
+jest.mock('react-native-webview', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const state = { instance: null };
+
+  const WebView = React.forwardRef(function MockWebView(props, ref) {
+    const inner = React.useRef({
+      injectJavaScript: jest.fn(),
+      reload: jest.fn(),
+    });
+
+    React.useImperativeHandle(ref, () => inner.current);
+
+    state.instance = {
+      props,
+      injectJavaScript: inner.current.injectJavaScript,
+      reload: inner.current.reload,
+    };
+
+    return React.createElement(View, { testID: 'mocked-webview' });
+  });
+
+  WebView.displayName = 'MockWebView';
+
+  // Expose the live state so tests can grab the latest instance.
+  global.__getMockWebView = () => state.instance;
+  global.__resetMockWebView = () => {
+    state.instance = null;
+  };
+
+  return { __esModule: true, WebView, default: WebView };
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "clean": "del-cli lib",
     "prepare": "bob build",
     "pack:local": "npm run clean && npm run prepare && npm pack",
+    "test": "jest",
+    "test:ci": "jest --ci --coverage",
     "release": "release-it"
   },
   "keywords": [
@@ -49,17 +51,23 @@
   "devDependencies": {
     "@react-native-community/cli": "15.0.1",
     "@release-it/conventional-changelog": "^9.0.3",
+    "@testing-library/react-native": "^12.7.2",
+    "@types/jest": "^29.5.12",
     "@types/react": "^18.2.44",
+    "@types/react-test-renderer": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
+    "babel-jest": "^29.7.0",
     "del-cli": "^6.0.0",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.0.0",
+    "jest": "^29.7.0",
     "prettier": "^3.0.3",
     "react": "18.3.1",
     "react-native": "0.76.3",
     "react-native-builder-bob": "^0.33.3",
     "react-native-webview": "^13.16.1",
+    "react-test-renderer": "18.3.1",
     "release-it": "^17.10.0",
     "typescript": "^5.7.2"
   },

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+import { act } from '@testing-library/react-native';
+import type { WebViewMessageEvent } from 'react-native-webview';
+
+interface MockWebView {
+  props: {
+    onLoadStart?: () => void;
+    onLoadEnd?: () => void;
+    onMessage?: (event: WebViewMessageEvent) => void;
+    onError?: () => void;
+    onHttpError?: () => void;
+  };
+  injectJavaScript: jest.Mock;
+  reload: jest.Mock;
+}
+
+declare const __getMockWebView: () => MockWebView | null;
+
+export function getWebView(): MockWebView {
+  const wv = __getMockWebView();
+  if (!wv) throw new Error('No mock WebView rendered yet');
+  return wv;
+}
+
+/** Simulate WebView dispatching a message back to the component */
+export function sendWebViewMessage(payload: object): void {
+  const wv = getWebView();
+  act(() => {
+    wv.props.onMessage?.({
+      nativeEvent: { data: JSON.stringify(payload) },
+    } as unknown as WebViewMessageEvent);
+  });
+}
+
+/** Drive the component through a successful load → ready cycle */
+export function loadAndReady(): void {
+  const wv = getWebView();
+  act(() => {
+    wv.props.onLoadStart?.();
+  });
+  act(() => {
+    wv.props.onLoadEnd?.();
+  });
+  sendWebViewMessage({ type: 'READY' });
+}
+
+/** Trigger the WebView's native onError */
+export function fireWebViewError(): void {
+  const wv = getWebView();
+  act(() => {
+    wv.props.onError?.();
+  });
+}
+
+/** A valid 40-char reCAPTCHA-shaped site key for tests */
+export const TEST_SITE_KEY = '6LcExampleExampleExampleExampleExample00';
+export const TEST_BASE_URL = 'https://example.com';

--- a/src/__tests__/lifecycle.test.tsx
+++ b/src/__tests__/lifecycle.test.tsx
@@ -1,0 +1,376 @@
+import { createRef } from 'react';
+import { act, render } from '@testing-library/react-native';
+import ReCaptcha, {
+  type GoogleRecaptchaRefAttributes,
+} from '../index';
+import {
+  TEST_BASE_URL,
+  TEST_SITE_KEY,
+  fireWebViewError,
+  getWebView,
+  loadAndReady,
+  sendWebViewMessage,
+} from './helpers';
+
+describe('getToken happy path', () => {
+  it('resolves with the token when WebView sends VERIFY', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+    const onVerify = jest.fn();
+
+    render(
+      <ReCaptcha
+        ref={ref}
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        onVerify={onVerify}
+      />
+    );
+
+    loadAndReady();
+
+    const tokenPromise = ref.current!.getToken('login');
+    sendWebViewMessage({ type: 'VERIFY', token: 'abc-token' });
+
+    await expect(tokenPromise).resolves.toBe('abc-token');
+    expect(onVerify).toHaveBeenCalledWith('abc-token', 'login');
+  });
+
+  it('queues getToken calls made before READY and processes them once ready', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    const tokenPromise = ref.current!.getToken('login');
+
+    loadAndReady();
+
+    sendWebViewMessage({ type: 'VERIFY', token: 'queued-token' });
+
+    await expect(tokenPromise).resolves.toBe('queued-token');
+  });
+
+  it('uses the default action when none is passed to getToken', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+    const onVerify = jest.fn();
+
+    render(
+      <ReCaptcha
+        ref={ref}
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        action="default_action"
+        onVerify={onVerify}
+      />
+    );
+
+    loadAndReady();
+
+    const tokenPromise = ref.current!.getToken();
+    sendWebViewMessage({ type: 'VERIFY', token: 'tok' });
+
+    await tokenPromise;
+    expect(onVerify).toHaveBeenCalledWith('tok', 'default_action');
+  });
+
+  it('injects the siteKey and action into the executed script', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+
+    ref.current!.getToken('checkout');
+
+    const wv = getWebView();
+    expect(wv.injectJavaScript).toHaveBeenCalled();
+    const injected = wv.injectJavaScript.mock.calls.pop()![0] as string;
+    expect(injected).toContain(TEST_SITE_KEY);
+    expect(injected).toContain("action: 'checkout'");
+  });
+});
+
+describe('error handling', () => {
+  it('rejects getToken with NETWORK_ERROR on WebView LOAD_ERROR', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+    const onError = jest.fn();
+
+    render(
+      <ReCaptcha
+        ref={ref}
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        onError={onError}
+      />
+    );
+    loadAndReady();
+
+    const tokenPromise = ref.current!.getToken('login');
+    sendWebViewMessage({ type: 'LOAD_ERROR', error: 'irrelevant' });
+
+    await expect(tokenPromise).rejects.toThrow(/network/i);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('rejects getToken with the WebView ERROR message', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+
+    const tokenPromise = ref.current!.getToken('login');
+    sendWebViewMessage({ type: 'ERROR', error: 'invalid-input-response' });
+
+    await expect(tokenPromise).rejects.toThrow('invalid-input-response');
+  });
+
+  it('treats WebView native onError as NETWORK_ERROR', async () => {
+    const onError = jest.fn();
+
+    render(
+      <ReCaptcha
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        onError={onError}
+      />
+    );
+    loadAndReady();
+
+    fireWebViewError();
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringMatching(/network connection/i)
+    );
+  });
+
+  it('rejects an invalid VERIFY (empty token) with INVALID_TOKEN', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+
+    const tokenPromise = ref.current!.getToken('login');
+    sendWebViewMessage({ type: 'VERIFY', token: '' });
+
+    await expect(tokenPromise).rejects.toThrow(/invalid token/i);
+  });
+});
+
+describe('siteKey validation', () => {
+  it('surfaces an INVALID_SITE_KEY error for malformed keys', () => {
+    const onError = jest.fn();
+
+    render(
+      <ReCaptcha
+        siteKey={"'; alert('xss'); var x='"}
+        baseUrl={TEST_BASE_URL}
+        onError={onError}
+      />
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringMatching(/invalid sitekey/i)
+    );
+  });
+
+  it('accepts a typical reCAPTCHA-shaped key', () => {
+    const onError = jest.fn();
+
+    render(
+      <ReCaptcha
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        onError={onError}
+      />
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('isReady()', () => {
+  it('returns false before READY', () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    expect(ref.current!.isReady()).toBe(false);
+  });
+
+  it('returns true after READY and no error', () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+    expect(ref.current!.isReady()).toBe(true);
+  });
+
+  it('returns false after an error, even if previously ready', () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+    sendWebViewMessage({ type: 'LOAD_ERROR' });
+    expect(ref.current!.isReady()).toBe(false);
+  });
+});
+
+describe('prop changes trigger reset', () => {
+  it('reloads the WebView when siteKey changes', () => {
+    const otherKey = TEST_SITE_KEY.replace('Example00', 'Example99');
+    const { rerender } = render(
+      <ReCaptcha siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+
+    const wv = getWebView();
+    const reloadCallsBefore = wv.reload.mock.calls.length;
+
+    rerender(<ReCaptcha siteKey={otherKey} baseUrl={TEST_BASE_URL} />);
+
+    expect(wv.reload.mock.calls.length).toBeGreaterThan(reloadCallsBefore);
+  });
+
+  it('does not reload on first mount', () => {
+    render(<ReCaptcha siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />);
+
+    expect(getWebView().reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('AbortSignal support', () => {
+  it('rejects with ABORTED if the signal is already aborted', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      ref.current!.getToken('login', { signal: controller.signal })
+    ).rejects.toThrow(/aborted/i);
+  });
+
+  it('aborts a pending (pre-ready) getToken', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    const controller = new AbortController();
+    const tokenPromise = ref.current!.getToken('login', {
+      signal: controller.signal,
+    });
+
+    act(() => {
+      controller.abort();
+    });
+
+    await expect(tokenPromise).rejects.toThrow(/aborted/i);
+  });
+
+  it('aborts an in-flight getToken', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+    loadAndReady();
+
+    const controller = new AbortController();
+    const tokenPromise = ref.current!.getToken('login', {
+      signal: controller.signal,
+    });
+
+    act(() => {
+      controller.abort();
+    });
+
+    await expect(tokenPromise).rejects.toThrow(/aborted/i);
+  });
+});
+
+describe('reCAPTCHA Enterprise mode', () => {
+  it('uses the enterprise.js script URL when useEnterprise is true', () => {
+    render(
+      <ReCaptcha
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        useEnterprise
+      />
+    );
+
+    const html = getWebView().props as unknown as {
+      source: { html: string };
+    };
+    expect(html.source.html).toContain('enterprise.js');
+    expect(html.source.html).not.toContain('api.js?render=');
+  });
+
+  it('uses the standard api.js script URL by default', () => {
+    render(
+      <ReCaptcha siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    const html = getWebView().props as unknown as {
+      source: { html: string };
+    };
+    expect(html.source.html).toContain('api.js?render=');
+    expect(html.source.html).not.toContain('enterprise.js');
+  });
+});
+
+describe('WebView security defaults', () => {
+  it('narrows originWhitelist to Google + baseUrl by default', () => {
+    render(<ReCaptcha siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />);
+
+    const props = getWebView().props as unknown as {
+      originWhitelist: string[];
+    };
+    expect(props.originWhitelist).toEqual(
+      expect.arrayContaining([
+        'https://www.google.com',
+        'https://www.gstatic.com',
+        TEST_BASE_URL,
+      ])
+    );
+    expect(props.originWhitelist).not.toContain('*');
+  });
+
+  it('lets consumers opt out with originWhitelist={["*"]}', () => {
+    render(
+      <ReCaptcha
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        originWhitelist={['*']}
+      />
+    );
+
+    const props = getWebView().props as unknown as {
+      originWhitelist: string[];
+    };
+    expect(props.originWhitelist).toEqual(['*']);
+  });
+
+  it("defaults mixedContentMode to 'never'", () => {
+    render(<ReCaptcha siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />);
+
+    const props = getWebView().props as unknown as {
+      mixedContentMode: string;
+    };
+    expect(props.mixedContentMode).toBe('never');
+  });
+});

--- a/src/__tests__/regressions.test.tsx
+++ b/src/__tests__/regressions.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for bugs fixed in the v2.4.0 lifecycle pass.
+ * Each describe block names the bug and links to the fix's expected behavior.
+ */
+import { createRef } from 'react';
+import { act, render } from '@testing-library/react-native';
+import ReCaptcha, {
+  type GoogleRecaptchaRefAttributes,
+} from '../index';
+import {
+  TEST_BASE_URL,
+  TEST_SITE_KEY,
+  getWebView,
+  loadAndReady,
+  sendWebViewMessage,
+} from './helpers';
+
+describe('Bug #1: onLoadEnd fires exactly once per load cycle', () => {
+  it('fires once even after the READY message arrives', () => {
+    const onLoadEnd = jest.fn();
+
+    render(
+      <ReCaptcha
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        onLoadEnd={onLoadEnd}
+      />
+    );
+
+    loadAndReady();
+
+    expect(onLoadEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires again after a reset+reload', async () => {
+    const onLoadEnd = jest.fn();
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha
+        ref={ref}
+        siteKey={TEST_SITE_KEY}
+        baseUrl={TEST_BASE_URL}
+        onLoadEnd={onLoadEnd}
+      />
+    );
+
+    loadAndReady();
+    expect(onLoadEnd).toHaveBeenCalledTimes(1);
+
+    let resetPromise!: Promise<void>;
+    act(() => {
+      resetPromise = ref.current!.reset();
+    });
+    loadAndReady(); // simulate reload completing
+    await resetPromise;
+
+    expect(onLoadEnd).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Bug #2: concurrent reset() calls do not leak promises', () => {
+  it('resolves all concurrent reset() promises', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    loadAndReady();
+
+    let resolved1 = false;
+    let resolved2 = false;
+    let p1!: Promise<unknown>;
+    let p2!: Promise<unknown>;
+    act(() => {
+      p1 = ref.current!.reset().then(() => {
+        resolved1 = true;
+      });
+      p2 = ref.current!.reset().then(() => {
+        resolved2 = true;
+      });
+    });
+
+    act(() => {
+      getWebView().props.onLoadEnd?.();
+    });
+
+    await Promise.all([p1, p2]);
+    expect(resolved1).toBe(true);
+    expect(resolved2).toBe(true);
+  });
+});
+
+describe('Bug #3: force-READY uses current state, not closure-captured stale', () => {
+  // We can't directly observe the closure issue, but we can verify that
+  // once READY arrives, subsequent timer-based injections do not flip
+  // state back or fire onLoadEnd again.
+  it('does not fire onLoadEnd again when force-READY runs after real READY', () => {
+    jest.useFakeTimers();
+    try {
+      const onLoadEnd = jest.fn();
+
+      render(
+        <ReCaptcha
+          siteKey={TEST_SITE_KEY}
+          baseUrl={TEST_BASE_URL}
+          onLoadEnd={onLoadEnd}
+        />
+      );
+
+      act(() => {
+        getWebView().props.onLoadStart?.();
+      });
+      act(() => {
+        getWebView().props.onLoadEnd?.();
+      });
+      sendWebViewMessage({ type: 'READY' });
+      expect(onLoadEnd).toHaveBeenCalledTimes(1);
+
+      // Advance past the 1s force-READY timer; it would re-inject and
+      // potentially flip things if state were stale.
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      // onLoadEnd should NOT have been called again
+      expect(onLoadEnd).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('Bug #4: reset() rejects in-flight and pending token requests', () => {
+  it('rejects a pending (pre-ready) getToken with RESET', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    const tokenPromise = ref.current!.getToken('login');
+    // Pre-attach a handler so the synchronous rejection during reset()
+    // doesn't fire as an unhandled rejection before our expect() runs.
+    tokenPromise.catch(() => undefined);
+
+    await act(async () => {
+      void ref.current!.reset();
+      // Flush microtasks so React processes the state updates from reset()
+      // (setIsReady/setHasError) inside this act() block.
+      await Promise.resolve();
+    });
+
+    await expect(tokenPromise).rejects.toThrow(/reset/i);
+  });
+
+  it('rejects an in-flight getToken with RESET', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    loadAndReady();
+
+    const tokenPromise = ref.current!.getToken('login');
+    tokenPromise.catch(() => undefined);
+
+    await act(async () => {
+      void ref.current!.reset();
+      // Flush microtasks so React processes the state updates from reset()
+      // (setIsReady/setHasError) inside this act() block.
+      await Promise.resolve();
+    });
+
+    await expect(tokenPromise).rejects.toThrow(/reset/i);
+  });
+});
+
+describe('Bug #5: superseded requests get SUPERSEDED, not TOKEN_REQUEST_TIMEOUT', () => {
+  it('rejects the older request with SUPERSEDED when a newer one starts', async () => {
+    const ref = createRef<GoogleRecaptchaRefAttributes>();
+
+    render(
+      <ReCaptcha ref={ref} siteKey={TEST_SITE_KEY} baseUrl={TEST_BASE_URL} />
+    );
+
+    loadAndReady();
+
+    const first = ref.current!.getToken('login');
+    const second = ref.current!.getToken('signup');
+
+    // Resolve only the second one to ensure first is rejected
+    sendWebViewMessage({ type: 'VERIFY', token: 'second-token' });
+
+    await expect(first).rejects.toThrow(/superseded/i);
+    await expect(second).resolves.toBe('second-token');
+  });
+});

--- a/src/__tests__/smoke.test.tsx
+++ b/src/__tests__/smoke.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react-native';
+import ReCaptcha from '../index';
+
+describe('ReCaptcha (smoke)', () => {
+  it('renders without crashing', () => {
+    const { UNSAFE_root } = render(
+      <ReCaptcha
+        siteKey="abcdefghij0123456789ABCDEFGHIJ0123456789"
+        baseUrl="https://example.com"
+      />
+    );
+    expect(UNSAFE_root).toBeTruthy();
+  });
+
+  it('exposes the mocked WebView to tests', () => {
+    render(
+      <ReCaptcha
+        siteKey="abcdefghij0123456789ABCDEFGHIJ0123456789"
+        baseUrl="https://example.com"
+      />
+    );
+    const webview = (global as unknown as { __getMockWebView: () => unknown }).__getMockWebView();
+    expect(webview).toBeTruthy();
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,30 +5,54 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
 } from 'react';
 import { StyleSheet, ViewStyle } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 
-// Constants
+// Public defaults
 const DEFAULT_ACTION = 'submit';
 const INITIALIZATION_TIMEOUT = 30000; // 30 seconds
 const TOKEN_REQUEST_TIMEOUT = 15000; // 15 seconds
 
+// Internal tuning
+const NETWORK_DETECTION_TIMEOUT_MS = 8000;
+const FORCE_READY_DELAY_MS = 1000;
+const SCRIPT_MAX_LOAD_TIME_MS = 3000;
+const SCRIPT_LOAD_TIMEOUT_MS = 10000;
+const SCRIPT_READY_TIMEOUT_MS = 5000;
+const SCRIPT_CHECK_INTERVAL_MS = 200;
+
+// Site keys are alphanumeric with - and _; reCAPTCHA keys are typically 40 chars
+const SITE_KEY_PATTERN = /^[A-Za-z0-9_-]{20,80}$/;
+
 // Error messages
 const ERROR_MESSAGES = {
-  NETWORK_ERROR: 'Network connection required. Please check your internet connection.',
-  INITIALIZATION_TIMEOUT: 'reCAPTCHA initialization timed out. Please check your internet connection.',
+  NETWORK_ERROR:
+    'Network connection required. Please check your internet connection.',
+  INITIALIZATION_TIMEOUT:
+    'reCAPTCHA initialization timed out. Please check your internet connection.',
   TOKEN_REQUEST_TIMEOUT: 'Token request timed out. Please try again.',
   NOT_READY: 'reCAPTCHA is not ready. Please wait and try again.',
   INVALID_TOKEN: 'Invalid token received from reCAPTCHA.',
+  SUPERSEDED: 'Token request superseded by a newer request.',
+  RESET: 'Token request cancelled: reCAPTCHA was reset.',
+  ABORTED: 'Token request was aborted.',
+  INVALID_SITE_KEY:
+    'Invalid siteKey. Expected a Google reCAPTCHA v3 site key (alphanumeric, dashes, underscores).',
 } as const;
 
 // Type definitions
+export interface GetTokenOptions {
+  /** Optional AbortSignal to cancel an in-flight token request. */
+  signal?: AbortSignal;
+}
+
 export interface ReCaptchaProps {
   siteKey: string;
   baseUrl: string;
   action?: string;
-  onVerify?: (token: string) => void;
+  onVerify?: (token: string, action: string) => void;
   onError?: (error: string) => void;
   onLoadStart?: () => void;
   onLoadEnd?: () => void;
@@ -37,10 +61,25 @@ export interface ReCaptchaProps {
   initializationTimeout?: number;
   tokenRequestTimeout?: number;
   testMode?: boolean;
+  /**
+   * Use reCAPTCHA Enterprise (grecaptcha.enterprise.execute) instead of the
+   * standard v3 endpoint. Defaults to false.
+   */
+  useEnterprise?: boolean;
+  /**
+   * Origins the WebView is allowed to navigate to. Defaults to a narrow set
+   * (Google reCAPTCHA + baseUrl) for safer browsing. Pass `['*']` to opt out.
+   */
+  originWhitelist?: readonly string[];
+  /**
+   * Android-only WebView setting controlling mixed (HTTP-in-HTTPS) content.
+   * Defaults to 'never' for safer behavior on a security-focused component.
+   */
+  mixedContentMode?: 'never' | 'always' | 'compatibility';
 }
 
 export interface GoogleRecaptchaRefAttributes {
-  getToken: (action?: string) => Promise<string>;
+  getToken: (action?: string, options?: GetTokenOptions) => Promise<string>;
   isReady: () => boolean;
   reset: () => Promise<void>;
 }
@@ -56,7 +95,9 @@ interface TokenRequest {
   resolve: (value: string) => void;
   reject: (reason: Error) => void;
   action: string;
-  timeoutId?: NodeJS.Timeout;
+  timeoutId?: ReturnType<typeof setTimeout>;
+  abortHandler?: () => void;
+  signal?: AbortSignal;
 }
 
 const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
@@ -74,24 +115,68 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
       initializationTimeout = INITIALIZATION_TIMEOUT,
       tokenRequestTimeout = TOKEN_REQUEST_TIMEOUT,
       testMode = false,
+      useEnterprise = false,
+      originWhitelist,
+      mixedContentMode = 'never',
     },
     ref
   ) => {
     const webViewRef = useRef<WebView>(null);
     const [isReady, setIsReady] = useState(false);
     const [hasError, setHasError] = useState(false);
-    
+
     const tokenRequestRef = useRef<TokenRequest | null>(null);
-    const initializationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const initializationTimeoutRef = useRef<ReturnType<
+      typeof setTimeout
+    > | null>(null);
     const pendingRequests = useRef<Array<TokenRequest>>([]);
     const prevSiteKeyRef = useRef<string | undefined>(undefined);
     const prevBaseUrlRef = useRef<string | undefined>(undefined);
-    const resetPromiseRef = useRef<{ resolve: () => void } | null>(null);
+    const resetResolvers = useRef<Array<() => void>>([]);
+    const hasFiredLoadEndRef = useRef(false);
+
+    // Mirror state into refs so timer callbacks can read the latest value
+    // without being captured-stale by their closure (bug fix: force-READY race).
+    const isReadyRef = useRef(isReady);
+    const hasErrorRef = useRef(hasError);
+    useEffect(() => {
+      isReadyRef.current = isReady;
+    }, [isReady]);
+    useEffect(() => {
+      hasErrorRef.current = hasError;
+    }, [hasError]);
 
     // Helper for conditional logging
-    const log = useCallback((...args: any[]) => {
-      if (testMode) console.log(...args);
-    }, [testMode]);
+    const log = useCallback(
+      (...args: unknown[]) => {
+        if (testMode) {
+          console.log(...args);
+        }
+      },
+      [testMode]
+    );
+
+    // Validate siteKey shape once per change. We don't throw — onError + hasError
+    // is the existing error channel, so we surface it that way.
+    const siteKeyInvalid = !SITE_KEY_PATTERN.test(siteKey);
+
+    // Detach an AbortSignal listener (no-op if not attached)
+    const detachAbortListener = (request: TokenRequest) => {
+      if (request.signal && request.abortHandler) {
+        request.signal.removeEventListener('abort', request.abortHandler);
+      }
+    };
+
+    // Safely reject a request once (swallow double-reject)
+    const safeReject = (request: TokenRequest, error: Error) => {
+      if (request.timeoutId) clearTimeout(request.timeoutId);
+      detachAbortListener(request);
+      try {
+        request.reject(error);
+      } catch {
+        // already rejected
+      }
+    };
 
     // Cleanup timeouts
     const cleanup = useCallback(() => {
@@ -110,13 +195,23 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
         cleanup();
         setIsReady(false);
         setHasError(false);
+        hasFiredLoadEndRef.current = false;
+
+        // Reject in-flight requests so callers don't hang until their own
+        // timeout fires (bug fix: pending request leak on reset).
+        const resetError = new Error(ERROR_MESSAGES.RESET);
+        if (tokenRequestRef.current) {
+          safeReject(tokenRequestRef.current, resetError);
+          tokenRequestRef.current = null;
+        }
+        const stillPending = pendingRequests.current;
         pendingRequests.current = [];
-        tokenRequestRef.current = null;
-        
-        // Store resolve function to call when WebView finishes loading
-        resetPromiseRef.current = { resolve };
-        
-        // Reload WebView - resolve will be called in handleLoadEnd
+        stillPending.forEach((req) => safeReject(req, resetError));
+
+        // Queue resolver - all queued resolvers fire on next handleLoadEnd
+        // (bug fix: concurrent reset() calls used to leak the first promise).
+        resetResolvers.current.push(resolve);
+
         webViewRef.current?.reload();
       });
     }, [cleanup]);
@@ -128,43 +223,35 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
         onError?.(error);
         setHasError(true);
 
-        // Reject current request
         if (tokenRequestRef.current) {
-          if (tokenRequestRef.current.timeoutId) {
-            clearTimeout(tokenRequestRef.current.timeoutId);
-          }
-          try {
-            tokenRequestRef.current.reject(new Error(error));
-          } catch (e) {
-            // Already rejected
-          }
+          safeReject(tokenRequestRef.current, new Error(error));
           tokenRequestRef.current = null;
         }
 
-        // Reject pending requests
-        pendingRequests.current.forEach((request) => {
-          if (request.timeoutId) clearTimeout(request.timeoutId);
-          try {
-            request.reject(new Error(error));
-          } catch (e) {
-            // Already rejected
-          }
-        });
+        const pending = pendingRequests.current;
         pendingRequests.current = [];
+        pending.forEach((request) => safeReject(request, new Error(error)));
       },
       [onError, log]
     );
 
-    // Initialize timeout - also detects if LOAD_ERROR never comes from WebView
+    // Initialize timeout - also detects if LOAD_ERROR never comes from WebView.
+    // Cap detection at NETWORK_DETECTION_TIMEOUT_MS so we fail fast on network
+    // issues regardless of the user-supplied initializationTimeout.
     useEffect(() => {
+      if (siteKeyInvalid) {
+        handleError(ERROR_MESSAGES.INVALID_SITE_KEY);
+        return;
+      }
       if (!isReady && !hasError) {
         initializationTimeoutRef.current = setTimeout(() => {
-          if (!isReady && !hasError) {
-            // If we haven't received READY or LOAD_ERROR after timeout, assume network error
-            log('[ReCaptcha] Initialization timeout - no response from WebView, assuming network error');
+          if (!isReadyRef.current && !hasErrorRef.current) {
+            log(
+              '[ReCaptcha] Initialization timeout - no response from WebView, assuming network error'
+            );
             handleError(ERROR_MESSAGES.NETWORK_ERROR);
           }
-        }, Math.min(initializationTimeout, 8000)); // Max 8 seconds to detect network issues
+        }, Math.min(initializationTimeout, NETWORK_DETECTION_TIMEOUT_MS));
       }
       return () => {
         if (initializationTimeoutRef.current) {
@@ -172,9 +259,16 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
           initializationTimeoutRef.current = null;
         }
       };
-    }, [isReady, hasError, initializationTimeout, handleError, log]);
+    }, [
+      isReady,
+      hasError,
+      initializationTimeout,
+      handleError,
+      log,
+      siteKeyInvalid,
+    ]);
 
-    // Reset on prop changes
+    // Reset on prop changes (siteKey or baseUrl)
     useEffect(() => {
       const isFirstMount = prevSiteKeyRef.current === undefined;
       if (isFirstMount) {
@@ -183,7 +277,10 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
         return;
       }
 
-      if (prevSiteKeyRef.current !== siteKey || prevBaseUrlRef.current !== baseUrl) {
+      if (
+        prevSiteKeyRef.current !== siteKey ||
+        prevBaseUrlRef.current !== baseUrl
+      ) {
         reset();
         prevSiteKeyRef.current = siteKey;
         prevBaseUrlRef.current = baseUrl;
@@ -195,7 +292,8 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
       (
         customAction: string,
         resolve: (value: string) => void,
-        reject: (reason: Error) => void
+        reject: (reason: Error) => void,
+        signal?: AbortSignal
       ) => {
         if (hasError) {
           reject(new Error(ERROR_MESSAGES.NETWORK_ERROR));
@@ -207,51 +305,66 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
           return;
         }
 
+        if (signal?.aborted) {
+          reject(new Error(ERROR_MESSAGES.ABORTED));
+          return;
+        }
+
         const request: TokenRequest = {
           resolve: (token: string) => {
             if (request.timeoutId) clearTimeout(request.timeoutId);
+            detachAbortListener(request);
             resolve(token);
           },
           reject: (error: Error) => {
             if (request.timeoutId) clearTimeout(request.timeoutId);
+            detachAbortListener(request);
             reject(error);
           },
           action: customAction,
+          signal,
         };
 
-        // Set timeout
         request.timeoutId = setTimeout(() => {
           if (tokenRequestRef.current === request) {
             tokenRequestRef.current = null;
           }
-          try {
-            request.reject(new Error(ERROR_MESSAGES.TOKEN_REQUEST_TIMEOUT));
-          } catch (e) {
-            // Already rejected
-          }
+          safeReject(request, new Error(ERROR_MESSAGES.TOKEN_REQUEST_TIMEOUT));
           onError?.(ERROR_MESSAGES.TOKEN_REQUEST_TIMEOUT);
         }, tokenRequestTimeout);
 
-        // If a previous request is still in-flight, reject it before overwriting
-        // so its promise doesn't hang until its own timeout fires.
+        if (signal) {
+          request.abortHandler = () => {
+            if (tokenRequestRef.current === request) {
+              tokenRequestRef.current = null;
+            }
+            safeReject(request, new Error(ERROR_MESSAGES.ABORTED));
+          };
+          signal.addEventListener('abort', request.abortHandler);
+        }
+
+        // Supersede any in-flight request with a SUPERSEDED error so the caller
+        // gets an accurate reason instead of TOKEN_REQUEST_TIMEOUT.
         const previous = tokenRequestRef.current;
         if (previous) {
-          if (previous.timeoutId) clearTimeout(previous.timeoutId);
-          try {
-            previous.reject(new Error(ERROR_MESSAGES.TOKEN_REQUEST_TIMEOUT));
-          } catch (e) {
-            // Already rejected
-          }
+          safeReject(previous, new Error(ERROR_MESSAGES.SUPERSEDED));
         }
         tokenRequestRef.current = request;
 
-        // Inject JavaScript
+        // Inject JavaScript. siteKey is regex-validated above, but escape
+        // action anyway since it's user-supplied.
         const escapedAction = customAction.replace(/'/g, "\\'");
+        const execCall = useEnterprise
+          ? 'window.grecaptcha.enterprise.execute'
+          : 'window.grecaptcha.execute';
+        const execCheck = useEnterprise
+          ? 'window.grecaptcha && window.grecaptcha.enterprise && window.grecaptcha.enterprise.execute'
+          : 'window.grecaptcha && window.grecaptcha.execute';
         const jsCode = `
           (function() {
             try {
-              if (window.grecaptcha && window.grecaptcha.execute) {
-                window.grecaptcha.execute('${siteKey}', { action: '${escapedAction}' })
+              if (${execCheck}) {
+                ${execCall}('${siteKey}', { action: '${escapedAction}' })
                   .then(function(token) {
                     if (token && typeof token === 'string' && token.length > 0) {
                       window.ReactNativeWebView.postMessage(
@@ -284,7 +397,7 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
 
         webViewRef.current?.injectJavaScript(jsCode);
       },
-      [isReady, hasError, siteKey, tokenRequestTimeout, onError]
+      [isReady, hasError, siteKey, tokenRequestTimeout, onError, useEnterprise]
     );
 
     // Process pending requests when ready
@@ -293,7 +406,14 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
         const requests = [...pendingRequests.current];
         pendingRequests.current = [];
         requests.forEach((request) => {
-          executeReCaptcha(request.action, request.resolve, request.reject);
+          if (request.timeoutId) clearTimeout(request.timeoutId);
+          detachAbortListener(request);
+          executeReCaptcha(
+            request.action,
+            request.resolve,
+            request.reject,
+            request.signal
+          );
         });
       }
     }, [isReady, executeReCaptcha]);
@@ -302,9 +422,15 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
     useImperativeHandle(
       ref,
       () => ({
-        getToken: (customAction = action) => {
+        getToken: (customAction = action, options?: GetTokenOptions) => {
           return new Promise<string>((resolve, reject) => {
-            // If there's an error (e.g., LOAD_ERROR when offline), reject immediately
+            const signal = options?.signal;
+
+            if (signal?.aborted) {
+              reject(new Error(ERROR_MESSAGES.ABORTED));
+              return;
+            }
+
             if (hasError) {
               reject(new Error(ERROR_MESSAGES.NETWORK_ERROR));
               return;
@@ -315,33 +441,60 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
                 resolve,
                 reject,
                 action: customAction,
+                signal,
               };
 
               request.timeoutId = setTimeout(() => {
                 const index = pendingRequests.current.indexOf(request);
                 if (index !== -1) {
                   pendingRequests.current.splice(index, 1);
-                  request.reject(new Error(ERROR_MESSAGES.INITIALIZATION_TIMEOUT));
+                  safeReject(
+                    request,
+                    new Error(ERROR_MESSAGES.INITIALIZATION_TIMEOUT)
+                  );
                 }
               }, initializationTimeout);
+
+              if (signal) {
+                request.abortHandler = () => {
+                  const index = pendingRequests.current.indexOf(request);
+                  if (index !== -1) {
+                    pendingRequests.current.splice(index, 1);
+                  }
+                  safeReject(request, new Error(ERROR_MESSAGES.ABORTED));
+                };
+                signal.addEventListener('abort', request.abortHandler);
+              }
 
               pendingRequests.current.push(request);
               return;
             }
 
-            executeReCaptcha(customAction, resolve, reject);
+            executeReCaptcha(customAction, resolve, reject, signal);
           });
         },
         isReady: () => isReady && !hasError,
-        reset: () => {
-          return reset();
-        },
+        reset: () => reset(),
       }),
       [action, isReady, hasError, initializationTimeout, executeReCaptcha, reset]
     );
 
-    // HTML content
-    const htmlContent = `
+    // HTML content - memoized so it isn't rebuilt on every render.
+    const htmlContent = useMemo(() => {
+      const scriptUrl = useEnterprise
+        ? `https://www.google.com/recaptcha/enterprise.js?render=${siteKey}`
+        : `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+      const readyCall = useEnterprise
+        ? 'window.grecaptcha.enterprise.ready'
+        : 'window.grecaptcha.ready';
+      const readyCheck = useEnterprise
+        ? 'window.grecaptcha && window.grecaptcha.enterprise && window.grecaptcha.enterprise.ready'
+        : 'window.grecaptcha && window.grecaptcha.ready';
+      const executeCheck = useEnterprise
+        ? 'window.grecaptcha && window.grecaptcha.enterprise && window.grecaptcha.enterprise.execute'
+        : 'window.grecaptcha && window.grecaptcha.execute';
+
+      return `
       <!DOCTYPE html>
       <html>
         <head>
@@ -351,9 +504,9 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
             var scriptLoadTimeout;
             var checkInterval;
             var scriptStartTime = Date.now();
-            var maxLoadTime = 3000; // 3 seconds max for script to load
+            var maxLoadTime = ${SCRIPT_MAX_LOAD_TIME_MS};
             var loadErrorSent = false;
-            
+
             function sendMessage(type, data) {
               if (window.ReactNativeWebView) {
                 window.ReactNativeWebView.postMessage(JSON.stringify({ type: type, ...data }));
@@ -361,9 +514,9 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
             }
 
             function sendLoadError(reason) {
-              if (loadErrorSent) return; // Prevent duplicate errors
+              if (loadErrorSent) return;
               loadErrorSent = true;
-              
+
               if (scriptLoadTimeout) clearTimeout(scriptLoadTimeout);
               if (checkInterval) clearInterval(checkInterval);
               if (testMode) {
@@ -373,23 +526,21 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
             }
 
             function initializeRecaptcha() {
-              if (window.grecaptcha && window.grecaptcha.ready) {
+              if (${readyCheck}) {
                 if (testMode) {
                   sendMessage('DEBUG', { message: '[WebView] Calling grecaptcha.ready...' });
                 }
                 try {
-                  // Set a timeout for grecaptcha.ready callback
                   var readyTimeout = setTimeout(function() {
                     if (!loadErrorSent) {
                       sendLoadError('grecaptcha.ready callback timeout');
                     }
-                  }, 5000);
-                  
-                  window.grecaptcha.ready(function() {
+                  }, ${SCRIPT_READY_TIMEOUT_MS});
+
+                  ${readyCall}(function() {
                     clearTimeout(readyTimeout);
-                    
-                    // Verify that execute function exists (means it's actually ready, not just cached)
-                    if (window.grecaptcha && window.grecaptcha.execute) {
+
+                    if (${executeCheck}) {
                       if (scriptLoadTimeout) clearTimeout(scriptLoadTimeout);
                       if (checkInterval) clearInterval(checkInterval);
                       if (testMode) {
@@ -397,7 +548,6 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
                       }
                       sendMessage('READY', {});
                     } else {
-                      // grecaptcha exists but execute doesn't - might be cached/incomplete
                       if (testMode) {
                         sendMessage('DEBUG', { message: '[WebView] grecaptcha.ready fired but execute not available, might be network issue' });
                       }
@@ -413,67 +563,57 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
               }
             }
 
-            // Aggressive periodic check to detect if script never loads
             checkInterval = setInterval(function() {
               if (loadErrorSent) {
                 clearInterval(checkInterval);
                 return;
               }
-              
+
               var elapsed = Date.now() - scriptStartTime;
-              
-              // Check if script is still loading after max time
+
               if (elapsed >= maxLoadTime) {
                 if (typeof window.grecaptcha === 'undefined') {
                   sendLoadError('reCAPTCHA script failed to load after ' + (elapsed / 1000) + ' seconds');
-                } else if (window.grecaptcha && !window.grecaptcha.execute) {
-                  // Try to initialize, and if it fails, send error
-                  if (!window.grecaptcha.ready) {
+                } else if (!(${executeCheck})) {
+                  if (!(${readyCheck})) {
                     sendLoadError('reCAPTCHA script incomplete - ready function missing');
                   } else {
-                    // Try initialize once more
                     initializeRecaptcha();
-                    // If still not ready after additional 2 seconds, send error
                     setTimeout(function() {
-                      if (!loadErrorSent && (!window.grecaptcha || !window.grecaptcha.execute)) {
+                      if (!loadErrorSent && !(${executeCheck})) {
                         sendLoadError('reCAPTCHA script incomplete after ' + ((elapsed + 2000) / 1000) + ' seconds');
                       }
                     }, 2000);
                   }
                 }
               }
-            }, 200); // Check every 200ms for faster detection
+            }, ${SCRIPT_CHECK_INTERVAL_MS});
 
-            // Set a timeout as fallback (longer than periodic checks)
             scriptLoadTimeout = setTimeout(function() {
               if (!loadErrorSent) {
                 if (typeof window.grecaptcha === 'undefined') {
-                  sendLoadError('reCAPTCHA script load timeout after 10 seconds');
-                } else if (window.grecaptcha && !window.grecaptcha.execute) {
-                  sendLoadError('reCAPTCHA script incomplete after 10 seconds');
+                  sendLoadError('reCAPTCHA script load timeout after ${SCRIPT_LOAD_TIMEOUT_MS / 1000} seconds');
+                } else if (!(${executeCheck})) {
+                  sendLoadError('reCAPTCHA script incomplete after ${SCRIPT_LOAD_TIMEOUT_MS / 1000} seconds');
                 }
               }
-            }, 10000); // 10 seconds timeout for script load
+            }, ${SCRIPT_LOAD_TIMEOUT_MS});
 
-            // Listen for all error events
             window.addEventListener('error', function(e) {
               if (loadErrorSent) return;
-              
-              // Check if it's a script loading error
+
               if (e.target && e.target.tagName === 'SCRIPT') {
                 sendLoadError('Script load error: ' + (e.message || 'Unknown'));
-              } else if (e.filename && e.filename.includes('recaptcha')) {
-                // Error related to reCAPTCHA script
+              } else if (e.filename && e.filename.indexOf('recaptcha') !== -1) {
                 sendLoadError('reCAPTCHA script error: ' + (e.message || 'Unknown'));
               }
             }, true);
 
-            // Listen for unhandled promise rejections (might catch network errors)
             window.addEventListener('unhandledrejection', function(e) {
               if (loadErrorSent) return;
-              
+
               var reason = e.reason || '';
-              if (reason.toString && (reason.toString().includes('network') || reason.toString().includes('fetch') || reason.toString().includes('Failed to fetch'))) {
+              if (reason.toString && (reason.toString().indexOf('network') !== -1 || reason.toString().indexOf('fetch') !== -1 || reason.toString().indexOf('Failed to fetch') !== -1)) {
                 sendLoadError('Network error detected: ' + reason);
               }
             });
@@ -491,12 +631,11 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
               sendLoadError('Script onerror fired - failed to load reCAPTCHA');
             }
 
-            // Expose for the script tag's onload/onerror handlers
             window.handleScriptLoad = handleScriptLoad;
             window.handleScriptError = handleScriptError;
           </script>
           <script
-            src="https://www.google.com/recaptcha/api.js?render=${siteKey}"
+            src="${scriptUrl}"
             onload="window.handleScriptLoad()"
             onerror="window.handleScriptError()"
           ></script>
@@ -506,6 +645,7 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
         </body>
       </html>
     `;
+    }, [siteKey, testMode, useEnterprise]);
 
     // Handle messages
     const handleMessage = useCallback(
@@ -523,16 +663,14 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
                 clearTimeout(initializationTimeoutRef.current);
                 initializationTimeoutRef.current = null;
               }
-              onLoadEnd?.();
               break;
 
             case 'VERIFY':
               if (data.token && data.token.length > 0) {
-                onVerify?.(data.token);
+                const verifiedAction =
+                  tokenRequestRef.current?.action ?? action;
+                onVerify?.(data.token, verifiedAction);
                 if (tokenRequestRef.current) {
-                  if (tokenRequestRef.current.timeoutId) {
-                    clearTimeout(tokenRequestRef.current.timeoutId);
-                  }
                   tokenRequestRef.current.resolve(data.token);
                   tokenRequestRef.current = null;
                 }
@@ -559,7 +697,7 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
           handleError('Failed to parse reCAPTCHA response');
         }
       },
-      [onVerify, onLoadEnd, handleError, log]
+      [onVerify, handleError, log, action]
     );
 
     // Handle WebView errors
@@ -571,33 +709,52 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
       setIsReady(false);
       setHasError(false);
       pendingRequests.current = [];
+      hasFiredLoadEndRef.current = false;
       onLoadStart?.();
     }, [onLoadStart]);
 
     const handleLoadEnd = useCallback(() => {
-      // Resolve reset promise if waiting
-      if (resetPromiseRef.current) {
-        resetPromiseRef.current.resolve();
-        resetPromiseRef.current = null;
+      // Resolve all queued reset() promises (handles concurrent reset() calls)
+      if (resetResolvers.current.length > 0) {
+        const resolvers = resetResolvers.current;
+        resetResolvers.current = [];
+        resolvers.forEach((r) => r());
       }
-      
-      // Inject check script to verify reCAPTCHA status and force READY if needed
-      if (!isReady && !hasError) {
+
+      // Fire onLoadEnd at most once per load cycle. handleLoadStart clears
+      // this flag on the next reload.
+      if (!hasFiredLoadEndRef.current) {
+        hasFiredLoadEndRef.current = true;
+        onLoadEnd?.();
+      }
+
+      // Force-READY safety net: if WebView load ended but the JS hasn't sent
+      // READY yet, probe state after a short delay. Use refs so we read the
+      // latest isReady/hasError, not closure-captured stale values.
+      if (!isReadyRef.current && !hasErrorRef.current) {
         setTimeout(() => {
-          if (!isReady && !hasError && webViewRef.current) {
+          if (
+            !isReadyRef.current &&
+            !hasErrorRef.current &&
+            webViewRef.current
+          ) {
+            const readyCheck = useEnterprise
+              ? 'window.grecaptcha && window.grecaptcha.enterprise && window.grecaptcha.enterprise.execute'
+              : 'window.grecaptcha && window.grecaptcha.execute';
+            const readyCallChain = useEnterprise
+              ? 'window.grecaptcha.enterprise.ready'
+              : 'window.grecaptcha.ready';
             const checkScript = `
               (function() {
                 if (window.ReactNativeWebView) {
-                  if (window.grecaptcha && window.grecaptcha.execute) {
+                  if (${readyCheck}) {
                     window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'READY' }));
-                  } else if (window.grecaptcha && window.grecaptcha.ready) {
+                  } else if (window.grecaptcha && (window.grecaptcha.ready || (window.grecaptcha.enterprise && window.grecaptcha.enterprise.ready))) {
                     try {
-                      window.grecaptcha.ready(function() {
+                      ${readyCallChain}(function() {
                         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'READY' }));
                       });
-                    } catch (e) {
-                      // Error already handled
-                    }
+                    } catch (e) {}
                   }
                 }
               })();
@@ -605,22 +762,26 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
             `;
             webViewRef.current.injectJavaScript(checkScript);
           }
-        }, 1000);
+        }, FORCE_READY_DELAY_MS);
       }
-      
-      onLoadEnd?.();
-    }, [onLoadEnd, isReady, hasError]);
+    }, [onLoadEnd, useEnterprise]);
+
+    const effectiveOriginWhitelist = originWhitelist ?? [
+      'https://www.google.com',
+      'https://www.gstatic.com',
+      baseUrl,
+    ];
 
     return (
       <WebView
         ref={webViewRef}
-        source={{ html: htmlContent.replace(/\s+/g, ' ').trim(), baseUrl }}
+        source={{ html: htmlContent, baseUrl }}
         onMessage={handleMessage}
         javaScriptEnabled={true}
         domStorageEnabled={true}
-        originWhitelist={['*']}
+        originWhitelist={effectiveOriginWhitelist as string[]}
         style={[styles.webview, style]}
-        mixedContentMode="always"
+        mixedContentMode={mixedContentMode}
         containerStyle={[styles.container, containerStyle]}
         onError={handleWebViewError}
         onHttpError={handleWebViewError}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,6 +134,9 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
     const prevBaseUrlRef = useRef<string | undefined>(undefined);
     const resetResolvers = useRef<Array<() => void>>([]);
     const hasFiredLoadEndRef = useRef(false);
+    const forceReadyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
 
     // Mirror state into refs so timer callbacks can read the latest value
     // without being captured-stale by their closure (bug fix: force-READY race).
@@ -178,7 +181,7 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
       }
     };
 
-    // Cleanup timeouts
+    // Cleanup timeouts (init + in-flight + queued)
     const cleanup = useCallback(() => {
       if (initializationTimeoutRef.current) {
         clearTimeout(initializationTimeoutRef.current);
@@ -187,6 +190,37 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
       if (tokenRequestRef.current?.timeoutId) {
         clearTimeout(tokenRequestRef.current.timeoutId);
       }
+      pendingRequests.current.forEach((req) => {
+        if (req.timeoutId) clearTimeout(req.timeoutId);
+      });
+    }, []);
+
+    // Unmount cleanup: clear timers and detach abort listeners so a
+    // teardown mid-flight doesn't leak timers or fire late callbacks.
+    useEffect(() => {
+      return () => {
+        if (initializationTimeoutRef.current) {
+          clearTimeout(initializationTimeoutRef.current);
+          initializationTimeoutRef.current = null;
+        }
+        if (forceReadyTimerRef.current) {
+          clearTimeout(forceReadyTimerRef.current);
+          forceReadyTimerRef.current = null;
+        }
+        if (tokenRequestRef.current) {
+          if (tokenRequestRef.current.timeoutId) {
+            clearTimeout(tokenRequestRef.current.timeoutId);
+          }
+          detachAbortListener(tokenRequestRef.current);
+          tokenRequestRef.current = null;
+        }
+        pendingRequests.current.forEach((req) => {
+          if (req.timeoutId) clearTimeout(req.timeoutId);
+          detachAbortListener(req);
+        });
+        pendingRequests.current = [];
+        resetResolvers.current = [];
+      };
     }, []);
 
     // Reset component - returns Promise that resolves when reset is complete
@@ -708,7 +742,10 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
     const handleLoadStart = useCallback(() => {
       setIsReady(false);
       setHasError(false);
-      pendingRequests.current = [];
+      // Intentionally do NOT clear pendingRequests here: requests the user
+      // queued between component mount and the WebView's first onLoadStart
+      // would be silently lost. reset() explicitly rejects + clears pendings
+      // when a controlled teardown is needed.
       hasFiredLoadEndRef.current = false;
       onLoadStart?.();
     }, [onLoadStart]);
@@ -731,8 +768,11 @@ const ReCaptchaV3 = forwardRef<GoogleRecaptchaRefAttributes, ReCaptchaProps>(
       // Force-READY safety net: if WebView load ended but the JS hasn't sent
       // READY yet, probe state after a short delay. Use refs so we read the
       // latest isReady/hasError, not closure-captured stale values.
+      if (forceReadyTimerRef.current) {
+        clearTimeout(forceReadyTimerRef.current);
+      }
       if (!isReadyRef.current && !hasErrorRef.current) {
-        setTimeout(() => {
+        forceReadyTimerRef.current = setTimeout(() => {
           if (
             !isReadyRef.current &&
             !hasErrorRef.current &&

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example", "lib"]
+  "exclude": [
+    "example",
+    "lib",
+    "node_modules",
+    "**/__tests__/*",
+    "**/__mocks__/*"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/code-frame@npm:7.29.0"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.28.5
+    js-tokens: ^4.0.0
+    picocolors: ^1.1.1
+  checksum: 39f5b303757e4d63bbff8133e251094cd4f952b46e3fa9febc7368d907583911d6a1eded6090876dc1feeff5cf6e134fb19b706f8d58d26c5402cd50e5e1aeb2
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.25.9, @babel/compat-data@npm:^7.26.0":
   version: 7.26.3
   resolution: "@babel/compat-data@npm:7.26.3"
   checksum: 85c5a9fb365231688c7faeb977f1d659da1c039e17b416f8ef11733f7aebe11fe330dce20c1844cacf243766c1d643d011df1d13cac9eda36c46c6c475693d21
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.28.6":
+  version: 7.29.3
+  resolution: "@babel/compat-data@npm:7.29.3"
+  checksum: 977192bab334f66bc8150026340a33ed318c1a7ce18a9323f4c1b86f8ed1d8645bfe5600242bf682717c05c46a4ff06225242207c1d599f4296914b9b4e3efb5
   languageName: node
   linkType: hard
 
@@ -56,6 +74,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.23.9":
+  version: 7.29.0
+  resolution: "@babel/core@npm:7.29.0"
+  dependencies:
+    "@babel/code-frame": ^7.29.0
+    "@babel/generator": ^7.29.0
+    "@babel/helper-compilation-targets": ^7.28.6
+    "@babel/helper-module-transforms": ^7.28.6
+    "@babel/helpers": ^7.28.6
+    "@babel/parser": ^7.29.0
+    "@babel/template": ^7.28.6
+    "@babel/traverse": ^7.29.0
+    "@babel/types": ^7.29.0
+    "@jridgewell/remapping": ^2.3.5
+    convert-source-map: ^2.0.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.3
+    semver: ^6.3.1
+  checksum: 85e1df6e213382c46dee27bcd07ed9202fa108a85bb74eb37be656308fd949349171ad2aa17cc84cf0720c908dc9ea6309d25e64d2a7fcdaa63721ce0c67c10b
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.20.0, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.26.0, @babel/generator@npm:^7.26.3":
   version: 7.26.3
   resolution: "@babel/generator@npm:7.26.3"
@@ -66,6 +107,19 @@ __metadata:
     "@jridgewell/trace-mapping": ^0.3.25
     jsesc: ^3.0.2
   checksum: fb09fa55c66f272badf71c20a3a2cee0fa1a447fed32d1b84f16a668a42aff3e5f5ddc6ed5d832dda1e952187c002ca1a5cdd827022efe591b6ac44cada884ea
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.29.0, @babel/generator@npm:^7.7.2":
+  version: 7.29.1
+  resolution: "@babel/generator@npm:7.29.1"
+  dependencies:
+    "@babel/parser": ^7.29.0
+    "@babel/types": ^7.29.0
+    "@jridgewell/gen-mapping": ^0.3.12
+    "@jridgewell/trace-mapping": ^0.3.28
+    jsesc: ^3.0.2
+  checksum: d8e6863b2d04f684e65ad72731049ac7d754d3a3d1a67cdfc20807b109ba3180ed90d7ccef58ce5d38ded2eaeb71983a76c711eecb9b6266118262378f6c7226
   languageName: node
   linkType: hard
 
@@ -88,6 +142,19 @@ __metadata:
     lru-cache: ^5.1.1
     semver: ^6.3.1
   checksum: 3af536e2db358b38f968abdf7d512d425d1018fef2f485d6f131a57a7bcaed32c606b4e148bb230e1508fa42b5b2ac281855a68eb78270f54698c48a83201b9b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
+  dependencies:
+    "@babel/compat-data": ^7.28.6
+    "@babel/helper-validator-option": ^7.27.1
+    browserslist: ^4.24.0
+    lru-cache: ^5.1.1
+    semver: ^6.3.1
+  checksum: 8151e36b74eb1c5e414fe945c189436421f7bfa011884de5be3dd7fd77f12f1f733ff7c982581dfa0a49d8af724450243c2409427114b4a6cfeb8333259d001c
   languageName: node
   linkType: hard
 
@@ -136,6 +203,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/helper-globals@npm:7.28.0"
+  checksum: d8d7b91c12dad1ee747968af0cb73baf91053b2bcf78634da2c2c4991fb45ede9bd0c8f9b5f3254881242bc0921218fcb7c28ae885477c25177147e978ce4397
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-member-expression-to-functions@npm:7.25.9"
@@ -156,6 +230,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-module-imports@npm:7.28.6"
+  dependencies:
+    "@babel/traverse": ^7.28.6
+    "@babel/types": ^7.28.6
+  checksum: 437513aa029898b588a38f7991d7656c539b22f595207d85d0c407240c9e3f2aff8b9d0d7115fdedc91e7fdce4465100549a052024e2fba6a810bcbb7584296b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.25.9, @babel/helper-module-transforms@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/helper-module-transforms@npm:7.26.0"
@@ -166,6 +250,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 942eee3adf2b387443c247a2c190c17c4fd45ba92a23087abab4c804f40541790d51ad5277e4b5b1ed8d5ba5b62de73857446b7742f835c18ebd350384e63917
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-module-transforms@npm:7.28.6"
+  dependencies:
+    "@babel/helper-module-imports": ^7.28.6
+    "@babel/helper-validator-identifier": ^7.28.5
+    "@babel/traverse": ^7.28.6
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 522f7d1d08b5e2ccd4ec912aca879bd1506af78d1fb30f46e3e6b4bb69c6ae6ab4e379a879723844230d27dc6d04a55b03f5215cd3141b7a2b40bb4a02f71a9f
   languageName: node
   linkType: hard
 
@@ -182,6 +279,13 @@ __metadata:
   version: 7.25.9
   resolution: "@babel/helper-plugin-utils@npm:7.25.9"
   checksum: e19ec8acf0b696756e6d84531f532c5fe508dce57aa68c75572a77798bd04587a844a9a6c8ea7d62d673e21fdc174d091c9097fb29aea1c1b49f9c6eaa80f022
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-plugin-utils@npm:7.28.6"
+  checksum: a0b4caab5e2180b215faa4d141ceac9e82fad9d446b8023eaeb8d82a6e62024726675b07fe8e616dd12f34e2bb59747e8d57aa8adab3e0717d1b8d691b118379
   languageName: node
   linkType: hard
 
@@ -228,6 +332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
+  checksum: 0a8464adc4b39b138aedcb443b09f4005d86207d7126e5e079177e05c3116107d856ec08282b365e9a79a9872f40f4092a6127f8d74c8a01c1ef789dacfc25d6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
@@ -235,10 +346,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
+  checksum: 5a251a6848e9712aea0338f659a1a3bd334d26219d5511164544ca8ec20774f098c3a6661e9da65a0d085c745c00bb62c8fada38a62f08fa1f8053bc0aeb57e4
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
   checksum: 9491b2755948ebbdd68f87da907283698e663b5af2d2b1b02a2765761974b1120d5d8d49e9175b167f16f72748ffceec8c9cf62acfbee73f4904507b246e2b3d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-validator-option@npm:7.27.1"
+  checksum: db73e6a308092531c629ee5de7f0d04390835b21a263be2644276cb27da2384b64676cab9f22cd8d8dbd854c92b1d7d56fc8517cf0070c35d1c14a8c828b0903
   languageName: node
   linkType: hard
 
@@ -263,6 +388,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.28.6":
+  version: 7.29.2
+  resolution: "@babel/helpers@npm:7.29.2"
+  dependencies:
+    "@babel/template": ^7.28.6
+    "@babel/types": ^7.29.0
+  checksum: 2c8ce711a639ef334539d3bd48977f57493f71af99e13d3f685fe47b3bc32aa83dbc1380688e19d5df924d958f8f29072f3dcff8110257ba6399524907287189
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.3":
   version: 7.26.3
   resolution: "@babel/parser@npm:7.26.3"
@@ -271,6 +406,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: e2bff2e9fa6540ee18fecc058bc74837eda2ddcecbe13454667314a93fc0ba26c1fb862c812d84f6d5f225c3bd8d191c3a42d4296e287a882c4e1f82ff2815ff
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.23.9, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
+  version: 7.29.3
+  resolution: "@babel/parser@npm:7.29.3"
+  dependencies:
+    "@babel/types": ^7.29.0
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 046f46996bf4053b6e29f8a7f420f9e0a2878593c1c9a9914a36faca23fc544a307c78a0101ba3ae98936ade68bdde686a83e1ab2b74c2ebb80dc4a9df48476d
   languageName: node
   linkType: hard
 
@@ -522,6 +668,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-jsx@npm:^7.7.2":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-jsx@npm:7.28.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.28.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 572e38f5c1bb4b8124300e7e3dd13e82ae84a21f90d3f0786c98cd05e63c78ca1f32d1cfe462dfbaf5e7d5102fa7cd8fd741dfe4f3afc2e01a3b2877dcc8c866
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
@@ -618,6 +775,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 0e9821e8ba7d660c36c919654e4144a70546942ae184e85b8102f2322451eae102cbfadbcadd52ce077a2b44b400ee52394c616feab7b5b9f791b910e933fd33
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.7.2":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-typescript@npm:7.28.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.28.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 5c55f9c63bd36cf3d7e8db892294c8f85000f9c1526c3a1cc310d47d1e174f5c6f6605e5cc902c4636d885faba7a9f3d5e5edc6b35e4f3b1fd4c2d58d0304fa5
   languageName: node
   linkType: hard
 
@@ -1516,6 +1684,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/template@npm:7.28.6"
+  dependencies:
+    "@babel/code-frame": ^7.28.6
+    "@babel/parser": ^7.28.6
+    "@babel/types": ^7.28.6
+  checksum: 8ab6383053e226025d9491a6e795293f2140482d14f60c1244bece6bf53610ed1e251d5e164de66adab765629881c7d9416e1e540c716541d2fd0f8f36a013d7
+  languageName: node
+  linkType: hard
+
 "@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3, @babel/traverse@npm:^7.20.0, @babel/traverse@npm:^7.25.3, @babel/traverse@npm:^7.25.9":
   version: 7.26.4
   resolution: "@babel/traverse@npm:7.26.4"
@@ -1531,6 +1710,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/traverse@npm:7.29.0"
+  dependencies:
+    "@babel/code-frame": ^7.29.0
+    "@babel/generator": ^7.29.0
+    "@babel/helper-globals": ^7.28.0
+    "@babel/parser": ^7.29.0
+    "@babel/template": ^7.28.6
+    "@babel/types": ^7.29.0
+    debug: ^4.3.1
+  checksum: fbb5085aa525b5d4ecd9fe2f5885d88413fff6ad9c0fac244c37f96069b6d3af9ce825750cd16af1d97d26fa3d354b38dbbdb5f31430e0d99ed89660ab65430e
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.2, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.26.3, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.26.3
   resolution: "@babel/types@npm:7.26.3"
@@ -1538,6 +1732,23 @@ __metadata:
     "@babel/helper-string-parser": ^7.25.9
     "@babel/helper-validator-identifier": ^7.25.9
   checksum: 195f428080dcaadbcecc9445df7f91063beeaa91b49ccd78f38a5af6b75a6a58391d0c6614edb1ea322e57889a1684a0aab8e667951f820196901dd341f931e9
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/types@npm:7.29.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.27.1
+    "@babel/helper-validator-identifier": ^7.28.5
+  checksum: 83f190438e94c22b2574aaeef7501830311ef266eaabfb06523409f64e2fe855e522951607085d71cad286719adef14e1ba37b671f334a7cd25b0f8506a01e0b
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 850f9305536d0f2bd13e9e0881cb5f02e4f93fad1189f7b2d4bebf694e3206924eadee1068130d43c11b750efcc9405f88a8e42ef098b6d75239c0f047de1a27
   languageName: node
   linkType: hard
 
@@ -1762,6 +1973,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@istanbuljs/schema@npm:^0.1.3":
+  version: 0.1.6
+  resolution: "@istanbuljs/schema@npm:0.1.6"
+  checksum: e0700df94e5eee184a64e9712d28a4aa8a0918f01e01e6fe50b93e12c2415c6930065c1622306a3bb28f8774e5aa3291671597826a71fa38f4b5667566e87bba
+  languageName: node
+  linkType: hard
+
+"@jest/console@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/console@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
+    slash: ^3.0.0
+  checksum: 0e3624e32c5a8e7361e889db70b170876401b7d70f509a2538c31d5cd50deb0c1ae4b92dc63fe18a0902e0a48c590c21d53787a0df41a52b34fa7cab96c384d6
+  languageName: node
+  linkType: hard
+
+"@jest/core@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/core@npm:29.7.0"
+  dependencies:
+    "@jest/console": ^29.7.0
+    "@jest/reporters": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    jest-changed-files: ^29.7.0
+    jest-config: ^29.7.0
+    jest-haste-map: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-regex-util: ^29.6.3
+    jest-resolve: ^29.7.0
+    jest-resolve-dependencies: ^29.7.0
+    jest-runner: ^29.7.0
+    jest-runtime: ^29.7.0
+    jest-snapshot: ^29.7.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
+    jest-watcher: ^29.7.0
+    micromatch: ^4.0.4
+    pretty-format: ^29.7.0
+    slash: ^3.0.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: af759c9781cfc914553320446ce4e47775ae42779e73621c438feb1e4231a5d4862f84b1d8565926f2d1aab29b3ec3dcfdc84db28608bdf5f29867124ebcfc0d
+  languageName: node
+  linkType: hard
+
 "@jest/create-cache-key-function@npm:^29.6.3":
   version: 29.7.0
   resolution: "@jest/create-cache-key-function@npm:29.7.0"
@@ -1783,6 +2056,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/expect-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect-utils@npm:29.7.0"
+  dependencies:
+    jest-get-type: ^29.6.3
+  checksum: 75eb177f3d00b6331bcaa057e07c0ccb0733a1d0a1943e1d8db346779039cb7f103789f16e502f888a3096fb58c2300c38d1f3748b36a7fa762eb6f6d1b160ed
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect@npm:29.7.0"
+  dependencies:
+    expect: ^29.7.0
+    jest-snapshot: ^29.7.0
+  checksum: a01cb85fd9401bab3370618f4b9013b90c93536562222d920e702a0b575d239d74cecfe98010aaec7ad464f67cf534a353d92d181646a4b792acaa7e912ae55e
+  languageName: node
+  linkType: hard
+
 "@jest/fake-timers@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/fake-timers@npm:29.7.0"
@@ -1797,12 +2089,96 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/globals@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/globals@npm:29.7.0"
+  dependencies:
+    "@jest/environment": ^29.7.0
+    "@jest/expect": ^29.7.0
+    "@jest/types": ^29.6.3
+    jest-mock: ^29.7.0
+  checksum: 97dbb9459135693ad3a422e65ca1c250f03d82b2a77f6207e7fa0edd2c9d2015fbe4346f3dc9ebff1678b9d8da74754d4d440b7837497f8927059c0642a22123
+  languageName: node
+  linkType: hard
+
+"@jest/reporters@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/reporters@npm:29.7.0"
+  dependencies:
+    "@bcoe/v8-coverage": ^0.2.3
+    "@jest/console": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@jridgewell/trace-mapping": ^0.3.18
+    "@types/node": "*"
+    chalk: ^4.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-instrument: ^6.0.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.0
+    istanbul-reports: ^3.1.3
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
+    jest-worker: ^29.7.0
+    slash: ^3.0.0
+    string-length: ^4.0.1
+    strip-ansi: ^6.0.0
+    v8-to-istanbul: ^9.0.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 7eadabd62cc344f629024b8a268ecc8367dba756152b761bdcb7b7e570a3864fc51b2a9810cd310d85e0a0173ef002ba4528d5ea0329fbf66ee2a3ada9c40455
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/schemas@npm:29.6.3"
   dependencies:
     "@sinclair/typebox": ^0.27.8
   checksum: 910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
+  languageName: node
+  linkType: hard
+
+"@jest/source-map@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/source-map@npm:29.6.3"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.18
+    callsites: ^3.0.0
+    graceful-fs: ^4.2.9
+  checksum: bcc5a8697d471396c0003b0bfa09722c3cd879ad697eb9c431e6164e2ea7008238a01a07193dfe3cbb48b1d258eb7251f6efcea36f64e1ebc464ea3c03ae2deb
+  languageName: node
+  linkType: hard
+
+"@jest/test-result@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-result@npm:29.7.0"
+  dependencies:
+    "@jest/console": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: 67b6317d526e335212e5da0e768e3b8ab8a53df110361b80761353ad23b6aea4432b7c5665bdeb87658ea373b90fb1afe02ed3611ef6c858c7fba377505057fa
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-sequencer@npm:29.7.0"
+  dependencies:
+    "@jest/test-result": ^29.7.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.7.0
+    slash: ^3.0.0
+  checksum: 73f43599017946be85c0b6357993b038f875b796e2f0950487a82f4ebcb115fa12131932dd9904026b4ad8be131fe6e28bd8d0aa93b1563705185f9804bff8bd
   languageName: node
   linkType: hard
 
@@ -1856,6 +2232,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.12":
+  version: 0.3.13
+  resolution: "@jridgewell/gen-mapping@npm:0.3.13"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.5.0
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: f2105acefc433337145caa3c84bba286de954f61c0bc46279bbd85a9e6a02871089717fa060413cfb6a9d44189fe8313b2d1cabf3a2eb3284d208fd5f75c54ff
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.8
   resolution: "@jridgewell/gen-mapping@npm:0.3.8"
@@ -1864,6 +2250,16 @@ __metadata:
     "@jridgewell/sourcemap-codec": ^1.4.10
     "@jridgewell/trace-mapping": ^0.3.24
   checksum: c0687b5227461717aa537fe71a42e356bcd1c43293b3353796a148bf3b0d6f59109def46c22f05b60e29a46f19b2e4676d027959a7c53a6c92b9d5b0d87d0420
+  languageName: node
+  linkType: hard
+
+"@jridgewell/remapping@npm:^2.3.5":
+  version: 2.3.5
+  resolution: "@jridgewell/remapping@npm:2.3.5"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.5
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: 4a66a7397c3dc9c6b5c14a0024b1f98c5e1d90a0dbc1e5955b5038f2db339904df2a0ee8a66559fafb4fc23ff33700a2639fd40bbdd2e9e82b58b3bdf83738e3
   languageName: node
   linkType: hard
 
@@ -1895,6 +2291,23 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 05df4f2538b3b0f998ea4c1cd34574d0feba216fa5d4ccaef0187d12abf82eafe6021cec8b49f9bb4d90f2ba4582ccc581e72986a5fcf4176ae0cfeb04cf52ec
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: c2e36e67971f719a8a3a85ef5a5f580622437cc723c35d03ebd0c9c0b06418700ef006f58af742791f71f6a4fc68fcfaf1f6a74ec2f9a3332860e9373459dae7
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.28":
+  version: 0.3.31
+  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.1.0
+    "@jridgewell/sourcemap-codec": ^1.4.14
+  checksum: af8fda2431348ad507fbddf8e25f5d08c79ecc94594061ce402cf41bc5aba1a7b3e59bf0fd70a619b35f33983a3f488ceeba8faf56bff784f98bb5394a8b7d47
   languageName: node
   linkType: hard
 
@@ -2555,6 +2968,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react-native@npm:^12.7.2":
+  version: 12.9.0
+  resolution: "@testing-library/react-native@npm:12.9.0"
+  dependencies:
+    jest-matcher-utils: ^29.7.0
+    pretty-format: ^29.7.0
+    redent: ^3.0.0
+  peerDependencies:
+    jest: ">=28.0.0"
+    react: ">=16.8.0"
+    react-native: ">=0.59"
+    react-test-renderer: ">=16.8.0"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 88115b22c127f39b2e1e8098dc1c93ea9c7393800a24f4f380bed64425cc685f98cad5b56b9cb48d85f0dbed1f0f208d0de44137c6e789c98161ff2715f70646
+  languageName: node
+  linkType: hard
+
 "@tootallnate/quickjs-emscripten@npm:^0.23.0":
   version: 0.23.0
   resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
@@ -2619,7 +3051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
@@ -2641,6 +3073,16 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "*"
   checksum: 93eb18835770b3431f68ae9ac1ca91741ab85f7606f310a34b3586b5a34450ec038c3eed7ab19266635499594de52ff73723a54a72a75b9f7d6a956f01edee95
+  languageName: node
+  linkType: hard
+
+"@types/jest@npm:^29.5.12":
+  version: 29.5.14
+  resolution: "@types/jest@npm:29.5.14"
+  dependencies:
+    expect: ^29.0.0
+    pretty-format: ^29.0.0
+  checksum: 18dba4623f26661641d757c63da2db45e9524c9be96a29ef713c703a9a53792df9ecee9f7365a0858ddbd6440d98fe6b65ca67895ca5884b73cbc7ffc11f3838
   languageName: node
   linkType: hard
 
@@ -2680,6 +3122,25 @@ __metadata:
   version: 15.7.14
   resolution: "@types/prop-types@npm:15.7.14"
   checksum: d0c5407b9ccc3dd5fae0ccf9b1007e7622ba5e6f1c18399b4f24dff33619d469da4b9fa918a374f19dc0d9fe6a013362aab0b844b606cfc10676efba3f5f736d
+  languageName: node
+  linkType: hard
+
+"@types/react-test-renderer@npm:^18.3.0":
+  version: 18.3.1
+  resolution: "@types/react-test-renderer@npm:18.3.1"
+  dependencies:
+    "@types/react": ^18
+  checksum: f8cc23cc8decdb6068cdc8f8c306e189eab8e569443ce97b216e757ee42eb20b18d2280ef41e2955668413f14be92765a3ba86cfcfeeae6b20c965acd9674786
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18":
+  version: 18.3.29
+  resolution: "@types/react@npm:18.3.29"
+  dependencies:
+    "@types/prop-types": "*"
+    csstype: ^3.2.2
+  checksum: 17e0efcfecfdb36e07aed7e259dc731fabcc1c4b1172d960152a357a6d1f54b6b775ce6d64be2e75030f9a221172198ceb8325f7b8c02c3ac5e69e58d3d7db69
   languageName: node
   linkType: hard
 
@@ -2850,17 +3311,23 @@ __metadata:
   dependencies:
     "@react-native-community/cli": 15.0.1
     "@release-it/conventional-changelog": ^9.0.3
+    "@testing-library/react-native": ^12.7.2
+    "@types/jest": ^29.5.12
     "@types/react": ^18.2.44
+    "@types/react-test-renderer": ^18.3.0
     "@typescript-eslint/eslint-plugin": ^8.18.0
     "@typescript-eslint/parser": ^8.18.0
+    babel-jest: ^29.7.0
     del-cli: ^6.0.0
     eslint: ^9.17.0
     eslint-config-prettier: ^9.0.0
+    jest: ^29.7.0
     prettier: ^3.0.3
     react: 18.3.1
     react-native: 0.76.3
     react-native-builder-bob: ^0.33.3
     react-native-webview: ^13.16.1
+    react-test-renderer: 18.3.1
     release-it: ^17.10.0
     typescript: ^5.7.2
   peerDependencies:
@@ -2966,7 +3433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.3.2":
+"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -3544,6 +4011,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"char-regex@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "char-regex@npm:1.0.2"
+  checksum: b563e4b6039b15213114626621e7a3d12f31008bdce20f9c741d69987f62aeaace7ec30f6018890ad77b2e9b4d95324c9f5acfca58a9441e3b1dcdd1e2525d17
+  languageName: node
+  linkType: hard
+
 "chardet@npm:^0.7.0":
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
@@ -3604,6 +4078,13 @@ __metadata:
   version: 4.1.0
   resolution: "ci-info@npm:4.1.0"
   checksum: dcf286abdc1bb1c4218b91e4a617b49781b282282089b7188e1417397ea00c6b967848e2360fb9a6b10021bf18a627f20ef698f47c2c9c875aeffd1d2ea51d1e
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:^1.0.0":
+  version: 1.4.3
+  resolution: "cjs-module-lexer@npm:1.4.3"
+  checksum: 221a1661a9ff4944b472c85ac7cd5029b2f2dc7f6c5f4ecf887f261503611110b43a48acb6c07f8f04109c772d1637fdb20b31252bf27058f35aa97bf5ad8b12
   languageName: node
   linkType: hard
 
@@ -3690,6 +4171,20 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"co@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "co@npm:4.6.0"
+  checksum: 5210d9223010eb95b29df06a91116f2cf7c8e0748a9013ed853b53f362ea0e822f1e5bb054fb3cefc645239a4cf966af1f6133a3b43f40d591f3b68ed6cf0510
+  languageName: node
+  linkType: hard
+
+"collect-v8-coverage@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "collect-v8-coverage@npm:1.0.3"
+  checksum: ed1d1ebc9c05e7263fffa3ad6440031db6a1fdd9f574435aa689effcdfe9f2b93aba8ec600f9c7b99124cd6ff5d9415c17961d84ae829a72251a4fe668a49b63
   languageName: node
   linkType: hard
 
@@ -4067,6 +4562,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "create-jest@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    jest-config: ^29.7.0
+    jest-util: ^29.7.0
+    prompts: ^2.0.1
+  bin:
+    create-jest: bin/create-jest.js
+  checksum: 1427d49458adcd88547ef6fa39041e1fe9033a661293aa8d2c3aa1b4967cb5bf4f0c00436c7a61816558f28ba2ba81a94d5c962e8022ea9a883978fc8e1f2945
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -4082,6 +4594,13 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 8db785cc92d259102725b3c694ec0c823f5619a84741b5c7991b8ad135dfaa66093038a1cc63e03361a6cd28d122be48f2106ae72334e067dd619a51f49eddf7
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "csstype@npm:3.2.3"
+  checksum: cb882521b3398958a1ce6ca98c011aec0bde1c77ecaf8a1dd4db3b112a189939beae3b1308243b2fe50fc27eb3edeb0f73a5a4d91d928765dc6d5ecc7bda92ee
   languageName: node
   linkType: hard
 
@@ -4134,6 +4653,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dedent@npm:^1.0.0":
+  version: 1.7.2
+  resolution: "dedent@npm:1.7.2"
+  peerDependencies:
+    babel-plugin-macros: ^3.1.0
+  peerDependenciesMeta:
+    babel-plugin-macros:
+      optional: true
+  checksum: 58f46def0e0310f4c6298f648fa1b1f2de074879f9035ff08285279f91060bb9b3c83d9c918b3ef2be3e08705f8858dc9139d9931832d89788d6efd3021c535d
+  languageName: node
+  linkType: hard
+
 "deep-extend@npm:^0.6.0":
   version: 0.6.0
   resolution: "deep-extend@npm:0.6.0"
@@ -4148,7 +4679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^4.3.0":
+"deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.0":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 2024c6a980a1b7128084170c4cf56b0fd58a63f2da1660dcfe977415f27b17dbe5888668b59d0b063753f3220719d5e400b7f113609489c90160bb9a5518d052
@@ -4270,6 +4801,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-newline@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "detect-newline@npm:3.1.0"
+  checksum: ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "diff-sequences@npm:29.6.3"
+  checksum: f4914158e1f2276343d98ff5b31fc004e7304f5470bf0f1adb2ac6955d85a531a6458d33e87667f98f6ae52ebd3891bb47d420bb48a5bd8b7a27ee25b20e33aa
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -4315,6 +4860,13 @@ __metadata:
   version: 1.5.73
   resolution: "electron-to-chromium@npm:1.5.73"
   checksum: 9e23966afabda22090ebd603e8312af5045aca55f02b8490f5dc66e3bcd2dfefbe3ab0968a587050604e9f398bded342315aa2ec78e418d37c7f237c2a2c69b9
+  languageName: node
+  linkType: hard
+
+"emittery@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "emittery@npm:0.13.1"
+  checksum: 2b089ab6306f38feaabf4f6f02792f9ec85fc054fda79f44f6790e61bbf6bc4e1616afb9b232e0c5ec5289a8a452f79bfa6d905a6fd64e94b49981f0934001c6
   languageName: node
   linkType: hard
 
@@ -4419,6 +4971,13 @@ __metadata:
     accepts: ~1.3.7
     escape-html: ~1.0.3
   checksum: 73b7abb08fb751107e9bebecc33c40c0641a54be8bda8e4a045f3f5cb7b805041927fef5629ea39b1737799eb52fe2499ca531f11ac51b0294ccc4667d72cb91
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
   languageName: node
   linkType: hard
 
@@ -4677,6 +5236,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exit@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "exit@npm:0.1.2"
+  checksum: abc407f07a875c3961e4781dfcb743b58d6c93de9ab263f4f8c9d23bb6da5f9b7764fc773f86b43dd88030444d5ab8abcb611cb680fba8ca075362b77114bba3
+  languageName: node
+  linkType: hard
+
+"expect@npm:^29.0.0, expect@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "expect@npm:29.7.0"
+  dependencies:
+    "@jest/expect-utils": ^29.7.0
+    jest-get-type: ^29.6.3
+    jest-matcher-utils: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
+  checksum: 9257f10288e149b81254a0fda8ffe8d54a7061cd61d7515779998b012579d2b8c22354b0eb901daf0145f347403da582f75f359f4810c007182ad3fb318b5c0c
+  languageName: node
+  linkType: hard
+
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
@@ -4827,7 +5406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.1.0":
+"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
   dependencies:
@@ -5243,6 +5822,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hasown@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "hasown@npm:2.0.3"
+  dependencies:
+    function-bind: ^1.1.2
+  checksum: bb06756a13dc4e6d1f45993c86c23f12d167c6c30a7dcc907aec5042300b4eb255615a0e5ed2c65014b93bf8bfcff111d991032c5c01ddefb340aa64b329bd55
+  languageName: node
+  linkType: hard
+
 "hermes-estree@npm:0.23.1":
   version: 0.23.1
   resolution: "hermes-estree@npm:0.23.1"
@@ -5297,6 +5885,13 @@ __metadata:
   dependencies:
     lru-cache: ^10.0.1
   checksum: 467cf908a56556417b18e86ae3b8dee03c2360ef1d51e61c4028fe87f6f309b6ff038589c94b5666af207da9d972d5107698906aabeb78aca134641962a5c6f8
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
   languageName: node
   linkType: hard
 
@@ -5424,6 +6019,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-local@npm:^3.0.2":
+  version: 3.2.0
+  resolution: "import-local@npm:3.2.0"
+  dependencies:
+    pkg-dir: ^4.2.0
+    resolve-cwd: ^3.0.0
+  bin:
+    import-local-fixture: fixtures/cli.js
+  checksum: 0b0b0b412b2521739fbb85eeed834a3c34de9bc67e670b3d0b86248fc460d990a7b116ad056c084b87a693ef73d1f17268d6a5be626bb43c998a8b1c8a230004
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -5548,6 +6155,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-core-module@npm:^2.16.1":
+  version: 2.16.2
+  resolution: "is-core-module@npm:2.16.2"
+  dependencies:
+    hasown: ^2.0.3
+  checksum: 9317844b4959f8fb268bfc1b4e24033d60058235c2e7273499c2abfd8e4510e7059b1339bd9109766293747daa3e0b5a89095fb2825a866a4093563fe8fdf16f
+  languageName: node
+  linkType: hard
+
 "is-directory@npm:^0.3.1":
   version: 0.3.1
   resolution: "is-directory@npm:0.3.1"
@@ -5591,6 +6207,13 @@ __metadata:
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
+  languageName: node
+  linkType: hard
+
+"is-generator-fn@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "is-generator-fn@npm:2.1.0"
+  checksum: a6ad5492cf9d1746f73b6744e0c43c0020510b59d56ddcb78a91cbc173f09b5e6beff53d75c9c5a29feb618bfef2bf458e025ecf3a57ad2268e2fb2569f56215
   languageName: node
   linkType: hard
 
@@ -5860,7 +6483,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.2.0":
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
   checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
@@ -5880,6 +6503,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-instrument@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "istanbul-lib-instrument@npm:6.0.3"
+  dependencies:
+    "@babel/core": ^7.23.9
+    "@babel/parser": ^7.23.9
+    "@istanbuljs/schema": ^0.1.3
+    istanbul-lib-coverage: ^3.2.0
+    semver: ^7.5.4
+  checksum: 74104c60c65c4fa0e97cc76f039226c356123893929f067bfad5f86fe839e08f5d680354a68fead3bc9c1e2f3fa6f3f53cded70778e821d911e851d349f3545a
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: ^3.0.0
+    make-dir: ^4.0.0
+    supports-color: ^7.1.0
+  checksum: fd17a1b879e7faf9bb1dc8f80b2a16e9f5b7b8498fe6ed580a618c34df0bfe53d2abd35bf8a0a00e628fb7405462576427c7df20bbe4148d19c14b431c974b21
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "istanbul-lib-source-maps@npm:4.0.1"
+  dependencies:
+    debug: ^4.1.1
+    istanbul-lib-coverage: ^3.0.0
+    source-map: ^0.6.1
+  checksum: 21ad3df45db4b81852b662b8d4161f6446cd250c1ddc70ef96a585e2e85c26ed7cd9c2a396a71533cfb981d1a645508bc9618cae431e55d01a0628e7dec62ef2
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.3":
+  version: 3.2.0
+  resolution: "istanbul-reports@npm:3.2.0"
+  dependencies:
+    html-escaper: ^2.0.0
+    istanbul-lib-report: ^3.0.0
+  checksum: 72b4c8525276147908d28b0917bc675b1019836b638e50875521ca3b8ec63672681aa98dbab88a6f49ef798c08fe041d428abdcf84f4f3fcff5844eee54af65a
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^3.1.2":
   version: 3.4.3
   resolution: "jackspeak@npm:3.4.3"
@@ -5893,7 +6561,144 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^29.6.3":
+"jest-changed-files@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-changed-files@npm:29.7.0"
+  dependencies:
+    execa: ^5.0.0
+    jest-util: ^29.7.0
+    p-limit: ^3.1.0
+  checksum: 963e203893c396c5dfc75e00a49426688efea7361b0f0e040035809cecd2d46b3c01c02be2d9e8d38b1138357d2de7719ea5b5be21f66c10f2e9685a5a73bb99
+  languageName: node
+  linkType: hard
+
+"jest-circus@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-circus@npm:29.7.0"
+  dependencies:
+    "@jest/environment": ^29.7.0
+    "@jest/expect": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^1.0.0
+    is-generator-fn: ^2.0.0
+    jest-each: ^29.7.0
+    jest-matcher-utils: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-runtime: ^29.7.0
+    jest-snapshot: ^29.7.0
+    jest-util: ^29.7.0
+    p-limit: ^3.1.0
+    pretty-format: ^29.7.0
+    pure-rand: ^6.0.0
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 349437148924a5a109c9b8aad6d393a9591b4dac1918fc97d81b7fc515bc905af9918495055071404af1fab4e48e4b04ac3593477b1d5dcf48c4e71b527c70a7
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-cli@npm:29.7.0"
+  dependencies:
+    "@jest/core": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/types": ^29.6.3
+    chalk: ^4.0.0
+    create-jest: ^29.7.0
+    exit: ^0.1.2
+    import-local: ^3.0.2
+    jest-config: ^29.7.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
+    yargs: ^17.3.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 664901277a3f5007ea4870632ed6e7889db9da35b2434e7cb488443e6bf5513889b344b7fddf15112135495b9875892b156faeb2d7391ddb9e2a849dcb7b6c36
+  languageName: node
+  linkType: hard
+
+"jest-config@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-config@npm:29.7.0"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/test-sequencer": ^29.7.0
+    "@jest/types": ^29.6.3
+    babel-jest: ^29.7.0
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    deepmerge: ^4.2.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-circus: ^29.7.0
+    jest-environment-node: ^29.7.0
+    jest-get-type: ^29.6.3
+    jest-regex-util: ^29.6.3
+    jest-resolve: ^29.7.0
+    jest-runner: ^29.7.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
+    micromatch: ^4.0.4
+    parse-json: ^5.2.0
+    pretty-format: ^29.7.0
+    slash: ^3.0.0
+    strip-json-comments: ^3.1.1
+  peerDependencies:
+    "@types/node": "*"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    ts-node:
+      optional: true
+  checksum: 4cabf8f894c180cac80b7df1038912a3fc88f96f2622de33832f4b3314f83e22b08fb751da570c0ab2b7988f21604bdabade95e3c0c041068ac578c085cf7dff
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^29.6.3
+    jest-get-type: ^29.6.3
+    pretty-format: ^29.7.0
+  checksum: 08e24a9dd43bfba1ef07a6374e5af138f53137b79ec3d5cc71a2303515335898888fa5409959172e1e05de966c9e714368d15e8994b0af7441f0721ee8e1bb77
+  languageName: node
+  linkType: hard
+
+"jest-docblock@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-docblock@npm:29.7.0"
+  dependencies:
+    detect-newline: ^3.0.0
+  checksum: 66390c3e9451f8d96c5da62f577a1dad701180cfa9b071c5025acab2f94d7a3efc2515cfa1654ebe707213241541ce9c5530232cdc8017c91ed64eea1bd3b192
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-each@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    chalk: ^4.0.0
+    jest-get-type: ^29.6.3
+    jest-util: ^29.7.0
+    pretty-format: ^29.7.0
+  checksum: e88f99f0184000fc8813f2a0aa79e29deeb63700a3b9b7928b8a418d7d93cd24933608591dbbdea732b473eb2021c72991b5cc51a17966842841c6e28e6f691c
+  languageName: node
+  linkType: hard
+
+"jest-environment-node@npm:^29.6.3, jest-environment-node@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-environment-node@npm:29.7.0"
   dependencies:
@@ -5937,6 +6742,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-leak-detector@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-leak-detector@npm:29.7.0"
+  dependencies:
+    jest-get-type: ^29.6.3
+    pretty-format: ^29.7.0
+  checksum: e3950e3ddd71e1d0c22924c51a300a1c2db6cf69ec1e51f95ccf424bcc070f78664813bef7aed4b16b96dfbdeea53fe358f8aeaaea84346ae15c3735758f1605
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-matcher-utils@npm:29.7.0"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^29.7.0
+    jest-get-type: ^29.6.3
+    pretty-format: ^29.7.0
+  checksum: d7259e5f995d915e8a37a8fd494cb7d6af24cd2a287b200f831717ba0d015190375f9f5dc35393b8ba2aae9b2ebd60984635269c7f8cff7d85b077543b7744cd
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-message-util@npm:29.7.0"
@@ -5965,10 +6792,136 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-pnp-resolver@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "jest-pnp-resolver@npm:1.2.3"
+  peerDependencies:
+    jest-resolve: "*"
+  peerDependenciesMeta:
+    jest-resolve:
+      optional: true
+  checksum: db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
+  languageName: node
+  linkType: hard
+
 "jest-regex-util@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-regex-util@npm:29.6.3"
   checksum: 0518beeb9bf1228261695e54f0feaad3606df26a19764bc19541e0fc6e2a3737191904607fb72f3f2ce85d9c16b28df79b7b1ec9443aa08c3ef0e9efda6f8f2a
+  languageName: node
+  linkType: hard
+
+"jest-resolve-dependencies@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve-dependencies@npm:29.7.0"
+  dependencies:
+    jest-regex-util: ^29.6.3
+    jest-snapshot: ^29.7.0
+  checksum: aeb75d8150aaae60ca2bb345a0d198f23496494677cd6aefa26fc005faf354061f073982175daaf32b4b9d86b26ca928586344516e3e6969aa614cb13b883984
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve@npm:29.7.0"
+  dependencies:
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.7.0
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
+    resolve: ^1.20.0
+    resolve.exports: ^2.0.0
+    slash: ^3.0.0
+  checksum: 0ca218e10731aa17920526ec39deaec59ab9b966237905ffc4545444481112cd422f01581230eceb7e82d86f44a543d520a71391ec66e1b4ef1a578bd5c73487
+  languageName: node
+  linkType: hard
+
+"jest-runner@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runner@npm:29.7.0"
+  dependencies:
+    "@jest/console": ^29.7.0
+    "@jest/environment": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    emittery: ^0.13.1
+    graceful-fs: ^4.2.9
+    jest-docblock: ^29.7.0
+    jest-environment-node: ^29.7.0
+    jest-haste-map: ^29.7.0
+    jest-leak-detector: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-resolve: ^29.7.0
+    jest-runtime: ^29.7.0
+    jest-util: ^29.7.0
+    jest-watcher: ^29.7.0
+    jest-worker: ^29.7.0
+    p-limit: ^3.1.0
+    source-map-support: 0.5.13
+  checksum: f0405778ea64812bf9b5c50b598850d94ccf95d7ba21f090c64827b41decd680ee19fcbb494007cdd7f5d0d8906bfc9eceddd8fa583e753e736ecd462d4682fb
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runtime@npm:29.7.0"
+  dependencies:
+    "@jest/environment": ^29.7.0
+    "@jest/fake-timers": ^29.7.0
+    "@jest/globals": ^29.7.0
+    "@jest/source-map": ^29.6.3
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    cjs-module-lexer: ^1.0.0
+    collect-v8-coverage: ^1.0.0
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-mock: ^29.7.0
+    jest-regex-util: ^29.6.3
+    jest-resolve: ^29.7.0
+    jest-snapshot: ^29.7.0
+    jest-util: ^29.7.0
+    slash: ^3.0.0
+    strip-bom: ^4.0.0
+  checksum: d19f113d013e80691e07047f68e1e3448ef024ff2c6b586ce4f90cd7d4c62a2cd1d460110491019719f3c59bfebe16f0e201ed005ef9f80e2cf798c374eed54e
+  languageName: node
+  linkType: hard
+
+"jest-snapshot@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-snapshot@npm:29.7.0"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-jsx": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/types": ^7.3.3
+    "@jest/expect-utils": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^29.7.0
+    graceful-fs: ^4.2.9
+    jest-diff: ^29.7.0
+    jest-get-type: ^29.6.3
+    jest-matcher-utils: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
+    natural-compare: ^1.4.0
+    pretty-format: ^29.7.0
+    semver: ^7.5.3
+  checksum: 86821c3ad0b6899521ce75ee1ae7b01b17e6dfeff9166f2cf17f012e0c5d8c798f30f9e4f8f7f5bed01ea7b55a6bc159f5eda778311162cbfa48785447c237ad
   languageName: node
   linkType: hard
 
@@ -5986,7 +6939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-validate@npm:^29.6.3":
+"jest-validate@npm:^29.6.3, jest-validate@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-validate@npm:29.7.0"
   dependencies:
@@ -6000,6 +6953,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-watcher@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-watcher@npm:29.7.0"
+  dependencies:
+    "@jest/test-result": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    emittery: ^0.13.1
+    jest-util: ^29.7.0
+    string-length: ^4.0.1
+  checksum: 67e6e7fe695416deff96b93a14a561a6db69389a0667e9489f24485bb85e5b54e12f3b2ba511ec0b777eca1e727235b073e3ebcdd473d68888650489f88df92f
+  languageName: node
+  linkType: hard
+
 "jest-worker@npm:^29.6.3, jest-worker@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-worker@npm:29.7.0"
@@ -6009,6 +6978,25 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 30fff60af49675273644d408b650fc2eb4b5dcafc5a0a455f238322a8f9d8a98d847baca9d51ff197b6747f54c7901daa2287799230b856a0f48287d131f8c13
+  languageName: node
+  linkType: hard
+
+"jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest@npm:29.7.0"
+  dependencies:
+    "@jest/core": ^29.7.0
+    "@jest/types": ^29.6.3
+    import-local: ^3.0.2
+    jest-cli: ^29.7.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 17ca8d67504a7dbb1998cf3c3077ec9031ba3eb512da8d71cb91bcabb2b8995c4e4b292b740cb9bf1cbff5ce3e110b3f7c777b0cefb6f41ab05445f248d0ee0b
   languageName: node
   linkType: hard
 
@@ -6446,6 +7434,15 @@ __metadata:
     pify: ^4.0.1
     semver: ^5.6.0
   checksum: 043548886bfaf1820323c6a2997e6d2fa51ccc2586ac14e6f14634f7458b4db2daf15f8c310e2a0abd3e0cddc64df1890d8fc7263033602c47bb12cbfcf86aab
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: ^7.5.3
+  checksum: bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
   languageName: node
   linkType: hard
 
@@ -7049,6 +8046,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -7434,6 +8438,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -7600,7 +8611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.0.2":
+"p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
@@ -7837,7 +8848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.0":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
@@ -7871,6 +8882,15 @@ __metadata:
   dependencies:
     find-up: ^3.0.0
   checksum: 70c9476ffefc77552cc6b1880176b71ad70bfac4f367604b2b04efd19337309a4eec985e94823271c7c0e83946fa5aeb18cd360d15d10a5d7533e19344bfa808
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "pkg-dir@npm:4.2.0"
+  dependencies:
+    find-up: ^4.0.0
+  checksum: 9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
   languageName: node
   linkType: hard
 
@@ -7911,7 +8931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:
@@ -7955,7 +8975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.4.2":
+"prompts@npm:^2.0.1, prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:
@@ -8028,6 +9048,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 8d53bc02bed99eca0b65b505090152ee7e9bd67dd74f8ff32ba1c883b87234067c5bf68d2614759fb217d82594d7a92919e6df80f97885e7b12b42af4bd3316a
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -8075,17 +9102,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^17.0.1":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.0.0":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
   languageName: node
   linkType: hard
 
@@ -8195,6 +9222,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-shallow-renderer@npm:^16.15.0":
+  version: 16.15.0
+  resolution: "react-shallow-renderer@npm:16.15.0"
+  dependencies:
+    object-assign: ^4.1.1
+    react-is: ^16.12.0 || ^17.0.0 || ^18.0.0
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 6052c7e3e9627485120ebd8257f128aad8f56386fe8d42374b7743eac1be457c33506d153c7886b4e32923c0c352d402ab805ef9ca02dbcd8393b2bdeb6e5af8
+  languageName: node
+  linkType: hard
+
+"react-test-renderer@npm:18.3.1":
+  version: 18.3.1
+  resolution: "react-test-renderer@npm:18.3.1"
+  dependencies:
+    react-is: ^18.3.1
+    react-shallow-renderer: ^16.15.0
+    scheduler: ^0.23.2
+  peerDependencies:
+    react: ^18.3.1
+  checksum: e8e58e738835fab3801afb63f6bfe0fcf6e68ea39619fae5bdf47feefc36b1e4acb48c9dd139c7533611466eff1dfce6ffdda4b317e06aee663dda7d91438f26
+  languageName: node
+  linkType: hard
+
 "react@npm:18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -8279,6 +9331,16 @@ __metadata:
   dependencies:
     resolve: ^1.1.6
   checksum: fe76bf9c21875ac16e235defedd7cbd34f333c02a92546142b7911a0f7c7059d2e16f441fe6fb9ae203f459c05a31b2bcf26202896d89e390eda7514d5d2702b
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: ^4.0.0
+    strip-indent: ^3.0.0
+  checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 
@@ -8426,6 +9488,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-cwd@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-cwd@npm:3.0.0"
+  dependencies:
+    resolve-from: ^5.0.0
+  checksum: 546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
+  languageName: node
+  linkType: hard
+
 "resolve-from@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-from@npm:3.0.0"
@@ -8447,6 +9518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve.exports@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "resolve.exports@npm:2.0.3"
+  checksum: abfb9f98278dcd0c19b8a49bb486abfafa23df4636d49128ea270dc982053c3ef230a530aecda1fae1322873fdfa6c97674fc539651ddfdb375ac58e0b8ef6df
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.1.6, resolve@npm:^1.14.2, resolve@npm:^1.22.8":
   version: 1.22.9
   resolution: "resolve@npm:1.22.9"
@@ -8460,6 +9538,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.20.0":
+  version: 1.22.12
+  resolution: "resolve@npm:1.22.12"
+  dependencies:
+    es-errors: ^1.3.0
+    is-core-module: ^2.16.1
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 4dc5a614b32142ef9ab455b242ed33c472c4ea50df17dbe1e9dac5fe0eebd7d5fdb7cb9cc8ad2165e5e0f07694498a74e7fbd6cc1599e20d84682cce1b80a4dc
+  languageName: node
+  linkType: hard
+
 "resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.8#~builtin<compat/resolve>":
   version: 1.22.9
   resolution: "resolve@patch:resolve@npm%3A1.22.9#~builtin<compat/resolve>::version=1.22.9&hash=c3c19d"
@@ -8470,6 +9562,20 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 8db5c0f16ab65f58c036cb5be0964605c97c29b9fdf1e20f298ec027e2a4fd96ad0413aa14f6e761629956dc552cd478c2f9b6c5a07e37e4c85209090162501e
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
+  version: 1.22.12
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#~builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+  dependencies:
+    es-errors: ^1.3.0
+    is-core-module: ^2.16.1
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 0cc5b060cbe081c85c331ac2eb08e8a54f0a195b899d5001822e5d3e2b335da651b1eed3d259fea904c22a0da9324a061e0e7ceab5dbeb5bcab5250b625754e1
   languageName: node
   linkType: hard
 
@@ -8609,6 +9715,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
+  languageName: node
+  linkType: hard
+
 "selfsigned@npm:^2.4.1":
   version: 2.4.1
   resolution: "selfsigned@npm:2.4.1"
@@ -8643,6 +9758,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.3, semver@npm:^7.5.4":
+  version: 7.8.1
+  resolution: "semver@npm:7.8.1"
+  bin:
+    semver: bin/semver.js
+  checksum: c6486ac12dc85120fc1daac8001350a4cd8126933720da496b0e8b841f170a35d4856b898b5288dfe7c1771bcadbf32c582254eade40ba16f8b6d296625d2b33
   languageName: node
   linkType: hard
 
@@ -8819,6 +9943,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:0.5.13":
+  version: 0.5.13
+  resolution: "source-map-support@npm:0.5.13"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 933550047b6c1a2328599a21d8b7666507427c0f5ef5eaadd56b5da0fd9505e239053c66fe181bf1df469a3b7af9d775778eee283cbb7ae16b902ddc09e93a97
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -8946,6 +10080,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-length@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "string-length@npm:4.0.2"
+  dependencies:
+    char-regex: ^1.0.2
+    strip-ansi: ^6.0.0
+  checksum: ce85533ef5113fcb7e522bcf9e62cb33871aa99b3729cec5595f4447f660b0cefd542ca6df4150c97a677d58b0cb727a3fe09ac1de94071d05526c73579bf505
+  languageName: node
+  linkType: hard
+
 "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -9024,6 +10168,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-bom@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-bom@npm:4.0.0"
+  checksum: 9dbcfbaf503c57c06af15fe2c8176fb1bf3af5ff65003851a102749f875a6dbe0ab3b30115eccf6e805e9d756830d3e40ec508b62b3f1ddf3761a20ebe29d3f3
+  languageName: node
+  linkType: hard
+
 "strip-final-newline@npm:^2.0.0":
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
@@ -9035,6 +10186,15 @@ __metadata:
   version: 3.0.0
   resolution: "strip-final-newline@npm:3.0.0"
   checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: ^1.0.0
+  checksum: 18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
   languageName: node
   linkType: hard
 
@@ -9458,6 +10618,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-to-istanbul@npm:^9.0.1":
+  version: 9.3.0
+  resolution: "v8-to-istanbul@npm:9.3.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.12
+    "@types/istanbul-lib-coverage": ^2.0.1
+    convert-source-map: ^2.0.0
+  checksum: ded42cd535d92b7fd09a71c4c67fb067487ef5551cc227bfbf2a1f159a842e4e4acddaef20b955789b8d3b455b9779d036853f4a27ce15007f6364a4d30317ae
+  languageName: node
+  linkType: hard
+
 "validate-npm-package-license@npm:^3.0.4":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
@@ -9789,7 +10960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.5.1, yargs@npm:^17.6.2":
+"yargs@npm:^17.3.1, yargs@npm:^17.5.1, yargs@npm:^17.6.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Summary

A comprehensive audit-and-improve pass on `@valture/react-native-recaptcha-v3` covering five lifecycle bugs, security hardening, new API features, and previously-missing test + CI infrastructure.

**Suggested release:** 2.4.0 (per the `feat:` commit).

## Lifecycle bug fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | `onLoadEnd` fired 2–3× per load cycle | Tracked in a ref so it fires exactly once per cycle |
| 2 | Concurrent `reset()` calls leaked the first promise | Array of resolvers; all resolve on next `handleLoadEnd` |
| 3 | `handleLoadEnd`'s 1s force-READY timer read closure-stale `isReady`/`hasError` | Mirror state into refs the timer reads at fire time |
| 4 | `reset()` cleared `pendingRequests` without rejecting the queued promises | `safeReject` each with a clear `RESET` error before clearing |
| 5 | Superseded in-flight token requests rejected with `TOKEN_REQUEST_TIMEOUT` | New `SUPERSEDED` error message |

Two more bugs surfaced while writing the tests:
- `handleLoadStart` was silently dropping `getToken()` calls users had queued between mount and the WebView's first `onLoadStart`.
- No unmount cleanup ⇒ if the component unmounted with an in-flight request, the 15s timeout timer leaked. New `useEffect` cleanup clears init / force-READY / in-flight / pending timers and detaches abort listeners.

## Security

- **`mixedContentMode`** is now a configurable prop, defaulting to `'never'` (was hard-coded `'always'`). Consumers serving HTTPS-only have a safer default; HTTP-mixing setups can opt in.
- **`originWhitelist`** is now a configurable prop, defaulting to `['https://www.google.com', 'https://www.gstatic.com', baseUrl]` (was `['*']`). Pass `['*']` to opt out.
- **`siteKey` is regex-validated** (`/^[A-Za-z0-9_-]{20,80}$/`) at mount. Invalid keys surface via `onError` instead of being interpolated into the injected JS / script URL.

## New features

- **`AbortSignal` support** — `getToken(action, { signal })`. Cancels pending or in-flight requests; promise rejects with an `ABORTED` error.
- **`action` argument on `onVerify`** — `onVerify?: (token, action) => void`. Lets consumers route tokens when running multiple actions through one component. Non-breaking — existing handlers continue to work.
- **reCAPTCHA Enterprise** — new `useEnterprise?: boolean` prop. Switches to `https://www.google.com/recaptcha/enterprise.js` and `grecaptcha.enterprise.execute`.

## Refactor / polish

- `htmlContent` memoized over `[siteKey, testMode, useEnterprise]` (was rebuilt every render).
- All magic numbers (`SCRIPT_MAX_LOAD_TIME_MS`, `SCRIPT_LOAD_TIMEOUT_MS`, `SCRIPT_READY_TIMEOUT_MS`, `SCRIPT_CHECK_INTERVAL_MS`, `NETWORK_DETECTION_TIMEOUT_MS`, `FORCE_READY_DELAY_MS`) extracted to named constants.
- `NodeJS.Timeout` replaced with portable `ReturnType<typeof setTimeout>`.
- Stale `valture-react-native-recaptcha-v3-2.2.0.tgz` removed from the working tree (was untracked but cluttering the dir; `*.tgz` is already gitignored).

## Tests (new)

`jest` + `@testing-library/react-native` + `react-test-renderer`, with a controllable WebView mock in `jest.setup.js`. **32 tests, all green.**

- `regressions.test.tsx` — guards bugs #1–#5
- `lifecycle.test.tsx` — covers `getToken` happy/error paths, prop changes triggering reset, `isReady()`, `AbortSignal` (all three phases), Enterprise vs standard URLs, WebView security defaults
- `smoke.test.tsx` — sanity render

`babel.config.js` is now env-aware: the existing `bob` preset for builds, `@react-native/babel-preset` for tests (otherwise jest chokes on Flow types in `node_modules/react-native`).

`tsconfig.build.json` now explicitly excludes `__tests__/__mocks__` so `bob`'s `tsc` step doesn't pick up test files.

## CI (new)

`.github/workflows/ci.yml` runs lint · typecheck · test · build on push to `main` and on PRs, across Node 20 and 22. Uses Corepack so CI picks up the Yarn 3 version pinned in `.yarnrc.yml`. Yarn cache restored from `yarn.lock` hash.

## API additions (non-breaking)

```ts
// New props
useEnterprise?: boolean;             // default false
originWhitelist?: readonly string[]; // default narrow; pass ['*'] to opt out
mixedContentMode?: 'never' | 'always' | 'compatibility'; // default 'never'

// Extended signatures
onVerify?: (token: string, action: string) => void;       // gains action
getToken: (action?, options?: { signal?: AbortSignal })   // gains options
  => Promise<string>;
```

All existing call sites continue to compile and behave correctly — handlers that ignore the new `action` arg, callers that don't pass options.

## Test plan

- [ ] `yarn lint && yarn typecheck && yarn test && yarn prepare` all pass locally
- [ ] CI workflow runs green on this PR (will appear shortly after push)
- [ ] Smoke test in `beedee-frontend` against `yarn pack:local` output:
  - [ ] Token retrieval still works end-to-end
  - [ ] No `onLoadEnd` double-fires
  - [ ] No console warnings about WebView security defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)